### PR TITLE
Use NS_ERROR_ENUM for better NSError bridging in Swift.

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -82,7 +82,7 @@ static NSString *const kEMMCallbackPath = @"/emmcallback";
 static NSString *const kEMMVersion = @"1";
 
 // The error code for Google Identity.
-NSString *const kGIDSignInErrorDomain = @"com.google.GIDSignIn";
+NSErrorDomain const kGIDSignInErrorDomain = @"com.google.GIDSignIn";
 
 // Keychain constants for saving state in the authentication flow.
 static NSString *const kGTMAppAuthKeychainName = @"auth";

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -23,10 +23,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// The error domain for `NSError`s returned by the Google Identity SDK.
-extern NSString *const kGIDSignInErrorDomain;
+extern NSErrorDomain const kGIDSignInErrorDomain;
 
 /// A list of potential error codes returned from the Google Identity SDK.
-typedef NS_ENUM(NSInteger, GIDSignInErrorCode) {
+typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
   /// Indicates an unknown error has occurred.
   kGIDSignInErrorCodeUnknown = -1,
   /// Indicates a problem reading or writing to the application keychain.


### PR DESCRIPTION
https://github.com/apple/swift-evolution/blob/master/proposals/0112-nserror-bridging.md