### PR TITLE
Adds a flag to indicate the auth flow is restarting.

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -146,8 +146,8 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   OIDServiceConfiguration *_appAuthConfiguration;
   // AppAuth external user-agent session state.
   id<OIDExternalUserAgentSession> _currentAuthorizationFlow;
-   // Flag to indicate that the auth flow is restarting.
-   BOOL _restarting;
+  // Flag to indicate that the auth flow is restarting.
+  BOOL _restarting;
 }
 
 #pragma mark - Public methods


### PR DESCRIPTION
This avoids the completion handlers being invoked prematurely which precludes the auth flow from being restarted because of the cleaning up of internal states.