### PR TITLE
Have pod try use our internal sample app.

### DIFF
--- a/.cocoapods.yml
+++ b/.cocoapods.yml
@@ -1,5 +1,2 @@
 try:
-  install:
-    pre:
-      - git clone https://github.com/googlesamples/google-services
-  project: 'google-services/ios/signin/SignInExample.xcodeproj'
+  project: 'Sample/SignInSampleForPod.xcodeproj'


### PR DESCRIPTION
Use the sample app from our repo rather than the external quick start app when developers use 'pod try'.  We specify the SignInSampleForPod project here to avoid prompting the developer to choose between that and the SignInSample project which uses SPM.