### PR TITLE
Addition of promotional prompt strings to `en.lproj/GoogleSignIn.strings`

### DIFF
--- a/GoogleSignIn/Sources/Strings/en.lproj/GoogleSignIn.strings
+++ b/GoogleSignIn/Sources/Strings/en.lproj/GoogleSignIn.strings
@@ -4,6 +4,18 @@
 /* Long form sign-in button text */
 "Sign in with Google" = "Sign in with Google";
 
+/* The title of the promotional prompt to install the Google app. */
+"PromoTitle" = "Sign in with Google";
+
+/* The body message of the promotional prompt to install the Google app. */
+"PromoMessage" = "Get the free Google app and sign in to apps with your Google Account. No need to remember passwords.";
+
+/* The cancel button on the promotional prompt to install the Google app. */
+"PromoActionCancel" = "Cancel";
+
+/* The install button on the promotional prompt to install the Google app. */
+"PromoActionInstall" = "Get";
+
 /* The text for the button for user to acknowledge and dismiss a dialog. */
 "OK" = "OK";
 


### PR DESCRIPTION
There are some strings missing in `en.lproj/GoogleSignIn.strings` inside GoogleSignIn.bundle which is part of the iOS Google sign-in SDK, so adding them in to avoid crashes in apps that use them.

These strings already exist in `en_GB.lproj/GoogleSignIn.strings`, so just making them available in `en.lproj/GoogleSignIn.strings` as well.