### PR TITLE
Modify the private method `restoredGoogleUserFromPreviousSignIn`.

### DIFF
--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.h
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.h
@@ -51,7 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Creates the default options.
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
-                       presentingViewController:(nullable UIViewController *)presentingViewController
+                       presentingViewController:
+                           (nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                        callback:(GIDSignInCallback)callback;
 

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.m
@@ -21,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation GIDSignInInternalOptions
 
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
-                       presentingViewController:(nullable UIViewController *)presentingViewController
+                       presentingViewController:
+                           (nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                        callback:(GIDSignInCallback)callback {
   GIDSignInInternalOptions *options = [[GIDSignInInternalOptions alloc] init];

--- a/GoogleSignIn/Sources/GIDSignIn_Private.h
+++ b/GoogleSignIn/Sources/GIDSignIn_Private.h
@@ -30,8 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
 // Authenticates with extra options.
 - (void)signInWithOptions:(GIDSignInInternalOptions *)options;
 
-// Returns the previous sign-in user in the keychain without refreshing the access token.
-- (nullable GIDGoogleUser *)restoredGoogleUserFromPreviousSignIn;
+// Restores a previously authenticated user from the keychain synchronously without refreshing
+// the access token or making a userinfo request. The currentUser.profile will be nil unless
+// the profile data can be extracted from the ID token.
+//
+// @return NO if there is no user restored from the keychain.
+- (BOOL)restorePreviousSignInNoRefresh;
 
 @end
 

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -353,7 +353,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   XCTAssertTrue(signIn1 == signIn2, @"shared instance must be singleton");
 }
 
-- (void)testRestoredGoogleUserFromPreviousSignIn_hasPreviousUser {
+- (void)testRestorePreviousSignInNoRefresh_hasPreviousUser {
   [[[_authorization expect] andReturn:_authState] authState];
   OCMStub([_authState lastTokenResponse]).andReturn(_tokenResponse);
   OCMStub([_tokenResponse scope]).andReturn(nil);
@@ -367,21 +367,21 @@ static void *kTestObserverContext = &kTestObserverContext;
   OCMStub([idTokenDecoded initWithIDTokenString:OCMOCK_ANY]).andReturn(idTokenDecoded);
   OCMStub([idTokenDecoded subject]).andReturn(kFakeGaiaID);
 
-  GIDGoogleUser *previousUser = [_signIn restoredGoogleUserFromPreviousSignIn];
+  [_signIn restorePreviousSignInNoRefresh];
 
   [_authorization verify];
   [_authState verify];
   [_tokenResponse verify];
-  XCTAssertEqual(previousUser.userID, kFakeGaiaID);
+  XCTAssertEqual(_signIn.currentUser.userID, kFakeGaiaID);
 }
 
-- (void)testRestoredGoogleUserFromPreviousSignIn_hasNoPreviousUser {
+- (void)testRestoredPreviousSignInNoRefresh_hasNoPreviousUser {
   [[[_authorization expect] andReturn:nil] authState];
 
-  GIDGoogleUser *previousUser = [_signIn restoredGoogleUserFromPreviousSignIn];
+  [_signIn restorePreviousSignInNoRefresh];
 
   [_authorization verify];
-  XCTAssertNil(previousUser);
+  XCTAssertNil(_signIn.currentUser);
 }
 
 - (void)testHasPreviousSignIn_HasBeenAuthenticated {


### PR DESCRIPTION
- Rename the method `restoredGoogleUserFromPreviousSignIn` to `restorePreviousSignInNoRefresh`.
- In the implementation restores the previous sign-in user in the keychain and set it as the current account without refreshing the access token.