### PR TITLE
Fix compilation for Xcode13b3 and above 

### DIFF
--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -54,7 +54,7 @@ typedef enum {
 }
 
 - (BOOL)handleErrorFromResponse:(NSDictionary<NSString *, id> *)response
-                     completion:(void (^)(void))completion {
+                     completion:(void (^)(void))completion NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
   ErrorCode errorCode = ErrorCodeNone;
   NSURL *appVerificationURL;
   @synchronized(self) {  // for accessing _pendingDialog
@@ -147,7 +147,7 @@ typedef enum {
 };
 
 // Returns an alert controller for passcode required error.
-- (UIAlertController *)passcodeRequiredAlertWithCompletion:(void (^)(void))completion {
+- (UIAlertController *)passcodeRequiredAlertWithCompletion:(void (^)(void))completion NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
   UIAlertController *alert =
       [UIAlertController alertControllerWithTitle:[self unableToAccessString]
                                           message:[self passcodeRequiredString]
@@ -188,7 +188,7 @@ typedef enum {
 
 // Returns an alert controller for app verification required error.
 - (UIAlertController *)appVerificationRequiredAlertWithURL:(nullable NSURL *)url
-                                                completion:(void (^)(void))completion {
+                                                completion:(void (^)(void))completion NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
   UIAlertController *alert;
   if (url) {
     // If the URL is provided, prompt user to open this URL or cancel.

--- a/GoogleSignIn/Tests/Unit/GIDEMMErrorHandlerTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMErrorHandlerTest.m
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 // Expects opening a particular URL string in performing an action.
-- (void)expectOpenURLString:(NSString *)urlString inAction:(void (^)(void))action {
+- (void)expectOpenURLString:(NSString *)urlString inAction:(void (^)(void))action NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
   // Swizzle and mock [UIApplication sharedApplication] since it is unavailable in unit tests.
   id mockApplication = OCMStrictClassMock([UIApplication class]);
   [GULSwizzler swizzleClass:[UIApplication class]

--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,8 @@ let package = Package(
   dependencies: [
     .package(
       name: "AppAuth",
-      url: "https://github.com/openid/AppAuth-iOS.git",
-      "1.4.0" ..< "2.0.0"),
+      url: "https://github.com/Figo0o/AppAuth-iOS",
+      .revision("744e9f199baf48a104c6502bd4ca11bbc1d6c11f")),
     .package(
       name: "GTMAppAuth",
       url: "https://github.com/google/GTMAppAuth.git",


### PR DESCRIPTION
Starting Xcode13b3 we must explicitly mark methods as not usable for App Extensions.

This branch now points to a specific SPM commit fix for AppAuth

More info here in the [Xcode Release Notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes)