### PR TITLE
Always generate a clang module.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         flags: [
-	  '',
-	  '--use-libraries',
-	  '--use-static-frameworks'
-	]
+          '',
+          '--use-libraries',
+          '--use-static-frameworks'
+        ]
     steps:
     - uses: actions/checkout@v2
     - name: Update Bundler

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,13 @@ jobs:
 
   pod-lib-lint:
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        flags: [
+	  '',
+	  '--use-libraries',
+	  '--use-static-frameworks'
+	]
     steps:
     - uses: actions/checkout@v2
     - name: Update Bundler
@@ -20,7 +27,7 @@ jobs:
     - name: Install Ruby gems with Bundler
       run: bundle install
     - name: Lint podspec using local source
-      run: pod lib lint --verbose --allow-warnings
+      run: pod lib lint --verbose --allow-warnings ${{ matrix.flags }}
 
   spm-build-test:
     runs-on: macOS-latest

--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -37,7 +37,8 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
   }
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => 'GID_SDK_VERSION=' + s.version.to_s,
-    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
+    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
+    'DEFINES_MODULE' => 'YES'
   }
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {:ios => ios_deployment_target}

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -16,11 +16,8 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h"
-#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDConfiguration.h"
-#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDGoogleUser.h"
-#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDProfileData.h"
-#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h"
+// Test module imports
+@import GoogleSignIn;
 
 #import "GoogleSignIn/Sources/GIDGoogleUser_Private.h"
 #import "GoogleSignIn/Sources/GIDSignInInternalOptions.h"

--- a/Sample/Podfile
+++ b/Sample/Podfile
@@ -1,5 +1,4 @@
 platform :ios, '9.0'
-use_frameworks!
 
 target 'SampleForPod' do
   pod 'GoogleSignIn', :path => '../', :testspecs => ['unit']


### PR DESCRIPTION
Allow CocoaPods developers to use modules without requiring that `use_frameworks!` or `:modular_headers => true` be used their Podfile.

Resolves #32 and #33.