### PR TITLE
Mark signIn and addScopes methods as unavailable in app extensions.

### DIFF
--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -104,7 +104,8 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 ///     called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
-                       callback:(nullable GIDSignInCallback)callback;
+                       callback:(nullable GIDSignInCallback)callback
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
 /// Starts an interactive sign-in flow using the provided configuration and a login hint.
 ///
@@ -124,7 +125,8 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
-                       callback:(nullable GIDSignInCallback)callback;
+                       callback:(nullable GIDSignInCallback)callback
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
 /// Starts an interactive consent flow to add scopes to the current user's grants.
 ///
@@ -139,7 +141,8 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 ///     called asynchronously on the main queue.
 - (void)addScopes:(NSArray<NSString *> *)scopes
     presentingViewController:(UIViewController *)presentingViewController
-                    callback:(nullable GIDSignInCallback)callback;
+                    callback:(nullable GIDSignInCallback)callback
+    NS_EXTENSION_UNAVAILABLE("The add scopes flow is not supported in App Extensions.");
 
 /// Marks current user as being in the signed out state.
 - (void)signOut;

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -22,10 +22,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// The error domain for `NSError`s returned by the Google Identity SDK.
+/// The error domain for `NSError`s returned by the Google Sign-In SDK.
 extern NSErrorDomain const kGIDSignInErrorDomain;
 
-/// A list of potential error codes returned from the Google Identity SDK.
+/// A list of potential error codes returned from the Google Sign-In SDK.
 typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
   /// Indicates an unknown error has occurred.
   kGIDSignInErrorCodeUnknown = -1,
@@ -142,7 +142,7 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 - (void)addScopes:(NSArray<NSString *> *)scopes
     presentingViewController:(UIViewController *)presentingViewController
                     callback:(nullable GIDSignInCallback)callback
-    NS_EXTENSION_UNAVAILABLE("The add scopes flow is not supported in App Extensions.");
+    NS_EXTENSION_UNAVAILABLE("The add scopes flow is not supported in App Extensions."); 
 
 /// Marks current user as being in the signed out state.
 - (void)signOut;


### PR DESCRIPTION
To avoid a potential sharedApplication reference in AppAuth for an extension target, which would generate a runtime error, we will mark these methods as unavailable to extensions and catch any references at compile time.