### PR TITLE
Replace deprecated API calls

### DIFF
--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -99,9 +99,17 @@ typedef enum {
       completion();
       return;
     }
-    CGRect keyWindowBounds = CGRectIsEmpty(keyWindow.bounds) ?
+    UIWindow *alertWindow;
+    if (@available(iOS 13, *)) {
+      if (keyWindow.windowScene) {
+        alertWindow = [[UIWindow alloc] initWithWindowScene:keyWindow.windowScene];
+      }
+    }
+    if (!alertWindow) {
+      CGRect keyWindowBounds = CGRectIsEmpty(keyWindow.bounds) ?
         keyWindow.bounds : [UIScreen mainScreen].bounds;
-    UIWindow *alertWindow = [[UIWindow alloc] initWithFrame:keyWindowBounds];
+      alertWindow = [[UIWindow alloc] initWithFrame:keyWindowBounds];
+    }
     alertWindow.backgroundColor = [UIColor clearColor];
     alertWindow.rootViewController = [[UIViewController alloc] init];
     alertWindow.rootViewController.view.backgroundColor = [UIColor clearColor];

--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -15,11 +15,11 @@
 
 #if TARGET_OS_IOS
 
-#import "GoogleSignIn/Sources/GIDEMMErrorHandler.h"
+#import "third_party/objective_c/GoogleSignIn/Sources/GIDEMMErrorHandler.h"
 
 #import <UIKit/UIKit.h>
 
-#import "GoogleSignIn/Sources/GIDSignInStrings.h"
+#import "third_party/objective_c/GoogleSignIn/Sources/GIDSignInStrings.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -93,7 +93,12 @@ typedef enum {
   }
   // All UI must happen in the main thread.
   dispatch_async(dispatch_get_main_queue(), ^() {
-    UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+    UIWindow *keyWindow = [self keyWindow];
+    if (!keyWindow) {
+      // Shouldn't happen, just in case.
+      completion();
+      return;
+    }
     CGRect keyWindowBounds = CGRectIsEmpty(keyWindow.bounds) ?
         keyWindow.bounds : [UIScreen mainScreen].bounds;
     UIWindow *alertWindow = [[UIWindow alloc] initWithFrame:keyWindowBounds];
@@ -131,6 +136,33 @@ typedef enum {
     }
   });
   return YES;
+}
+
+// This method is exposed to the unit test.
+- (UIWindow *)keyWindow {
+  if (@available(iOS 15, *)) {
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+      if ([scene isKindOfClass:[UIWindowScene class]] &&
+          scene.activationState == UISceneActivationStateForegroundActive) {
+        return ((UIWindowScene *)scene).keyWindow;
+      }
+    }
+  } else {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_15_0
+    if (@available(iOS 13, *)) {
+      for (UIWindow *window in UIApplication.sharedApplication.windows) {
+        if (window.isKeyWindow) {
+          return window;
+        }
+      }
+    } else {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
+      return UIApplication.sharedApplication.keyWindow;
+#endif  // __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
+    }
+#endif  // __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_15_0
+  }
+  return nil;
 }
 
 #pragma mark - Alerts
@@ -176,8 +208,7 @@ typedef enum {
                                               style:UIAlertActionStyleDefault
                                             handler:^(UIAlertAction *action) {
       completion();
-      [[UIApplication sharedApplication]
-          openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+      [self openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
     }]];
   } else {
     [alert addAction:[UIAlertAction actionWithTitle:[self okayString]
@@ -207,7 +238,7 @@ typedef enum {
                                               style:UIAlertActionStyleDefault
                                             handler:^(UIAlertAction *action) {
       completion();
-      [[UIApplication sharedApplication] openURL:url];
+      [self openURL:url];
     }]];
   } else {
     // If the URL is not provided, simple let user acknowledge the issue. This is not supposed to
@@ -222,6 +253,16 @@ typedef enum {
     }]];
   }
   return alert;
+}
+
+- (void)openURL:(NSURL *)url {
+  if (@available(iOS 10, *)) {
+    [UIApplication.sharedApplication openURL:url options:@{} completionHandler:nil];
+  } else {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
+    [UIApplication.sharedApplication openURL:url];
+#endif  // __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
+  }
 }
 
 #pragma mark - Localization

--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -15,11 +15,11 @@
 
 #if TARGET_OS_IOS
 
-#import "third_party/objective_c/GoogleSignIn/Sources/GIDEMMErrorHandler.h"
+#import "GoogleSignIn/Sources/GIDEMMErrorHandler.h"
 
 #import <UIKit/UIKit.h>
 
-#import "third_party/objective_c/GoogleSignIn/Sources/GIDSignInStrings.h"
+#import "GoogleSignIn/Sources/GIDSignInStrings.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -147,7 +147,7 @@ typedef enum {
 }
 
 // This method is exposed to the unit test.
-- (UIWindow *)keyWindow {
+- (nullable UIWindow *)keyWindow {
   if (@available(iOS 15, *)) {
     for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
       if ([scene isKindOfClass:[UIWindowScene class]] &&

--- a/GoogleSignIn/Tests/Unit/GIDEMMErrorHandlerTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMErrorHandlerTest.m
@@ -18,17 +18,17 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "third_party/objective_c/GoogleSignIn/Sources/GIDEMMErrorHandler.h"
-#import "third_party/objective_c/GoogleSignIn/Sources/GIDSignInStrings.h"
+#import "GoogleSignIn/Sources/GIDEMMErrorHandler.h"
+#import "GoogleSignIn/Sources/GIDSignInStrings.h"
 
 #ifdef SWIFT_PACKAGE
 @import GoogleUtilities_MethodSwizzler;
 @import GoogleUtilities_SwizzlerTestHelpers;
 @import OCMock;
 #else
-#import "third_party/firebase/ios/Releases/GoogleUtilities/MethodSwizzler/Public/GoogleUtilities/GULSwizzler.h"
-#import "third_party/firebase/ios/Releases/GoogleUtilities/SwizzlerTestHelpers/Public/GoogleUtilities/GULSwizzler+Unswizzle.h"
-#import "third_party/objective_c/ocmock/v3/Source/OCMock/OCMock.h"
+#import <GoogleUtilities/GULSwizzler.h>
+#import <GoogleUtilities/GULSwizzler+Unswizzle.h>
+#import <OCMock/OCMock.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Replaces deprecated APIs with new ones on later iOS versions to avoid compiler warnings.