### PR TITLE
Fix alert window disappearance issue under scene-based lifecycle in GIDEMMErrorHandler

### DIFF
--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -95,22 +95,22 @@ typedef enum {
     // Compatible with different iOS lifecycles for UIWindow initialization.
     if (@available(iOS 13.0, *)) {
       for (UIWindow *window in [UIApplication sharedApplication].windows) {
-          if (window.isKeyWindow) {
-              keyWindow = window;
-              break;
-          }
+        if (window.isKeyWindow) {
+          keyWindow = window;
+          break;
+        }
       }
       if (!keyWindow || !(keyWindow.windowScene)) {
-          // The keyWindow and windowScene shouldn't be nil under iOS 13 and higher.
-          completion();
-          return;
+        // The keyWindow and windowScene shouldn't be nil under iOS 13 and higher.
+        completion();
+        return;
       }
       alertWindow = [[UIWindow alloc] initWithWindowScene:keyWindow.windowScene];
     } else {
-        keyWindow = [[UIApplication sharedApplication] keyWindow];
-        CGRect keyWindowBounds = CGRectIsEmpty(keyWindow.bounds) ?
-            keyWindow.bounds : [UIScreen mainScreen].bounds;
-        alertWindow  = [[UIWindow alloc] initWithFrame:keyWindowBounds];
+      keyWindow = [[UIApplication sharedApplication] keyWindow];
+      CGRect keyWindowBounds = CGRectIsEmpty(keyWindow.bounds) ?
+        keyWindow.bounds : [UIScreen mainScreen].bounds;
+      alertWindow  = [[UIWindow alloc] initWithFrame:keyWindowBounds];
     }
     alertWindow.backgroundColor = [UIColor clearColor];
     alertWindow.rootViewController = [[UIViewController alloc] init];

--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -92,13 +92,18 @@ typedef enum {
   dispatch_async(dispatch_get_main_queue(), ^() {
     UIWindow *keyWindow = nil;
     UIWindow *alertWindow = nil;
-    // Compatible with different iOS versions/lifecycles.
+    // Compatible with different iOS lifecycles for UIWindow initialization.
     if (@available(iOS 13.0, *)) {
       for (UIWindow *window in [UIApplication sharedApplication].windows) {
           if (window.isKeyWindow) {
               keyWindow = window;
               break;
           }
+      }
+      if (!keyWindow || !(keyWindow.windowScene)) {
+          // The keyWindow and windowScene shouldn't be nil under iOS 13 and higher.
+          completion();
+          return;
       }
       alertWindow = [[UIWindow alloc] initWithWindowScene:keyWindow.windowScene];
     } else {

--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -92,7 +92,7 @@ typedef enum {
   dispatch_async(dispatch_get_main_queue(), ^() {
     UIWindow *keyWindow = nil;
     UIWindow *alertWindow = nil;
-    // Compatible with different iOS versions.
+    // Compatible with different iOS versions/lifecycles.
     if (@available(iOS 13.0, *)) {
       for (UIWindow *window in [UIApplication sharedApplication].windows) {
           if (window.isKeyWindow) {

--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -90,10 +90,23 @@ typedef enum {
   }
   // All UI must happen in the main thread.
   dispatch_async(dispatch_get_main_queue(), ^() {
-    UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
-    CGRect keyWindowBounds = CGRectIsEmpty(keyWindow.bounds) ?
-        keyWindow.bounds : [UIScreen mainScreen].bounds;
-    UIWindow *alertWindow = [[UIWindow alloc] initWithFrame:keyWindowBounds];
+    UIWindow *keyWindow = nil;
+    UIWindow *alertWindow = nil;
+    // Compatible with different iOS versions.
+    if (@available(iOS 13.0, *)) {
+      for (UIWindow *window in [UIApplication sharedApplication].windows) {
+          if (window.isKeyWindow) {
+              keyWindow = window;
+              break;
+          }
+      }
+      alertWindow = [[UIWindow alloc] initWithWindowScene:keyWindow.windowScene];
+    } else {
+        keyWindow = [[UIApplication sharedApplication] keyWindow];
+        CGRect keyWindowBounds = CGRectIsEmpty(keyWindow.bounds) ?
+            keyWindow.bounds : [UIScreen mainScreen].bounds;
+        alertWindow  = [[UIWindow alloc] initWithFrame:keyWindowBounds];
+    }
     alertWindow.backgroundColor = [UIColor clearColor];
     alertWindow.rootViewController = [[UIViewController alloc] init];
     alertWindow.rootViewController.view.backgroundColor = [UIColor clearColor];


### PR DESCRIPTION
## PR Statement
Hi reviewers:

My app is currently using `GoogleSignIn` to support google account. However, I intend to migrate my app from app-based lifecycle to scene-based lifecycle(Which is announced by Apple at WWDC19). When I go through all the third-party dependencies, I found `GoogleSignIn/GIDEMMErrorHandler.m` have a potential risk under scene-based lifecycle: The error alert will never show up because alertWindow was not connected to UIWindowScene once the app adopt scene-based lifecycle. In this PR, I'm trying to make a minimum changes to support scene-based lifecycle.

## Future Improvement
For simplicity, my changes only support single-scene app and for multi-scene app it might show up the alertWindow at a wrong scene. But It should work fine in most cases. According to my understanding as a third-party contributor, support multi-scene in GoogleSignIn will be a heavy work. Because you need you store the UIWindowScene user interact with to login its account and pass it to initialize alertWindow at a proper time.

Looking forward to see your response.

Thanks.

