### PR TITLE
Import GTMFetcherAuthorizationProtocol in GIDAuthentication

### DIFF
--- a/GoogleSignIn/Sources/GIDAuthentication.m
+++ b/GoogleSignIn/Sources/GIDAuthentication.m
@@ -23,7 +23,6 @@
 
 #ifdef SWIFT_PACKAGE
 @import AppAuth;
-@import GTMAppAuth;
 #else
 #import <AppAuth/OIDAuthState.h>
 #import <AppAuth/OIDAuthorizationRequest.h>
@@ -33,7 +32,6 @@
 #import <AppAuth/OIDIDToken.h>
 #import <AppAuth/OIDTokenRequest.h>
 #import <AppAuth/OIDTokenResponse.h>
-#import <GTMAppAuth/GTMAppAuthFetcherAuthorization.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h
@@ -16,7 +16,14 @@
 
 #import <Foundation/Foundation.h>
 
-@protocol GTMFetcherAuthorizationProtocol;
+// We have to import GTMAppAuth because forward declaring the protocol does
+// not generate the `fetcherAuthorizer` method below for Swift.
+#ifdef SWIFT_PACKAGE
+@import GTMAppAuth;
+#else
+#import <GTMAppAuth/GTMAppAuthFetcherAuthorization.h>
+#endif
+
 @class GIDAuthentication;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -62,5 +69,6 @@ typedef void (^GIDAuthenticationAction)(GIDAuthentication *_Nullable authenticat
 - (void)doWithFreshTokens:(GIDAuthenticationAction)action;
 
 @end
+
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Forward declaring the protocol in GIDAuthentication led to a method vending a GTMFetcherAuthorizationProtocol conforming instance to not be visible in Swift. Fixes #106.