### PR TITLE
Add defaults for easier button instantiation

### DIFF
--- a/GoogleSignInSwift/Sources/GoogleSignInButton.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButton.swift
@@ -28,10 +28,12 @@ public struct GoogleSignInButton: View {
 
   /// Creates an instance of the Google Sign-In button for use in SwiftUI
   /// - parameter viewModel: An instance of `GoogleSignInButtonViewModel`
-  /// containing information on the button's scheme, style, and state.
+  /// containing information on the button's scheme, style, and state. Defaults to
+  /// `GoogleSignInButtonViewModel` with its standard defaults.
   /// - parameter action: A closure to use as the button's action upon press.
+  /// - seealso: Refer to `GoogleSignInButtonViewModel.swift` for its defaults.
   public init(
-    viewModel: GoogleSignInButtonViewModel,
+    viewModel: GoogleSignInButtonViewModel = GoogleSignInButtonViewModel(),
     action: @escaping () -> Void
   ) {
     self.viewModel = viewModel

--- a/GoogleSignInSwift/Sources/GoogleSignInButton.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButton.swift
@@ -41,6 +41,29 @@ public struct GoogleSignInButton: View {
     self.fontLoaded = Font.loadCGFont()
   }
 
+  /// A convenience initializer to create a Google Sign-In button in SwiftUI
+  /// with scheme, style, and state.
+  /// - parameter scheme: The `GoogleSignInButtonColorScheme` to use. Defaults
+  /// to `.light`.
+  /// - parameter style: The `GoogleSignInButtonStyle` to use. Defaults to
+  /// `.standard`.
+  /// - parameter state: The `GoogleSignInButtonState` to use. Defaults to
+  /// `.normal`.
+  /// - parameter action: A closure to use as the button's action upon press.
+  public init(
+    scheme: GoogleSignInButtonColorScheme = .light,
+    style: GoogleSignInButtonStyle = .standard,
+    state: GoogleSignInButtonState = .normal,
+    action: @escaping () -> Void
+  ) {
+    let vm = GoogleSignInButtonViewModel(
+      scheme: scheme,
+      style: style,
+      state: state
+    )
+    self.init(viewModel: vm, action: action)
+  }
+
   public var body: some View {
     Button(action: action) {
       switch viewModel.style {

--- a/GoogleSignInSwift/Sources/GoogleSignInButton.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButton.swift
@@ -29,8 +29,8 @@ public struct GoogleSignInButton: View {
 
   /// Creates an instance of the Google Sign-In button for use in SwiftUI
   /// - parameter viewModel: An instance of `GoogleSignInButtonViewModel`
-  /// containing information on the button's scheme, style, and state. Defaults to
-  /// `GoogleSignInButtonViewModel` with its standard defaults.
+  ///     containing information on the button's scheme, style, and state.
+  ///     Defaults to `GoogleSignInButtonViewModel` with its standard defaults.
   /// - parameter action: A closure to use as the button's action upon press.
   /// - seealso: Refer to `GoogleSignInButtonViewModel.swift` for its defaults.
   public init(
@@ -45,11 +45,11 @@ public struct GoogleSignInButton: View {
   /// A convenience initializer to create a Google Sign-In button in SwiftUI
   /// with scheme, style, and state.
   /// - parameter scheme: The `GoogleSignInButtonColorScheme` to use. Defaults
-  /// to `.light`.
+  ///     to `.light`.
   /// - parameter style: The `GoogleSignInButtonStyle` to use. Defaults to
-  /// `.standard`.
+  ///     `.standard`.
   /// - parameter state: The `GoogleSignInButtonState` to use. Defaults to
-  /// `.normal`.
+  ///     `.normal`.
   /// - parameter action: A closure to use as the button's action upon press.
   public init(
     scheme: GoogleSignInButtonColorScheme = .light,

--- a/GoogleSignInSwift/Sources/GoogleSignInButton.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButton.swift
@@ -22,7 +22,8 @@ import CoreGraphics
 /// A Google Sign In button to be used in SwiftUI.
 @available(iOS 13.0, macOS 10.15, *)
 public struct GoogleSignInButton: View {
-  @ObservedObject var viewModel: GoogleSignInButtonViewModel
+  /// An object containing the styling information needed to create the button.
+  @ObservedObject public var viewModel: GoogleSignInButtonViewModel
   private let action: () -> Void
   private let fontLoaded: Bool
 

--- a/GoogleSignInSwift/Sources/GoogleSignInButtonViewModel.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButtonViewModel.swift
@@ -31,14 +31,16 @@ public class GoogleSignInButtonViewModel: ObservableObject {
   }
 
   /// Creates instances of the SwiftUI sign-in button.
-  /// - parameter scheme: An instance of `GoogleSignInButtonColorScheme`.
-  /// - parameter style: An instance of `GoogleSignInButtonStyle`.
+  /// - parameter scheme: An instance of `GoogleSignInButtonColorScheme`. Defaults to
+  /// `.light`.
+  /// - parameter style: An instance of `GoogleSignInButtonStyle`. Defaults to
+  /// `.standard`.
   /// - parameter state: An instance of `GoogleSignInButtonState`. Defaults to
   /// `.normal`.
   @available(iOS 13.0, macOS 10.15, *)
   public init(
-    scheme: GoogleSignInButtonColorScheme,
-    style: GoogleSignInButtonStyle,
+    scheme: GoogleSignInButtonColorScheme = .light,
+    style: GoogleSignInButtonStyle = .standard,
     state: GoogleSignInButtonState = .normal) {
       self.scheme = scheme
       self.style = style

--- a/Samples/Swift/DaysUntilBirthday/Shared/Views/SignInView.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Views/SignInView.swift
@@ -23,14 +23,7 @@ struct SignInView: View {
   var body: some View {
     VStack {
       HStack {
-        let buttonViewModel = GoogleSignInButtonViewModel(
-          scheme: .light,
-          style: .standard
-        )
-        GoogleSignInButton(
-          viewModel: buttonViewModel,
-          action: authViewModel.signIn
-        )
+        GoogleSignInButton(action: authViewModel.signIn)
           .accessibility(hint: Text("Sign in with Google button."))
           .padding()
       }


### PR DESCRIPTION
Adds default values to the initializers for `GoogleSignInButtonViewModel` and `GoogleSignInButton` to facilitate easier instantiation.