### PR TITLE
Adds segmented controls to sample to preview button styling

### DIFF
--- a/GoogleSignInSwift/Sources/GoogleSignInButtonStyling.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButtonStyling.swift
@@ -51,29 +51,35 @@ let googleImageName = "google"
 ///
 /// The minimum size of the button depends on the language used for text.
 @available(iOS 13.0, macOS 10.15, *)
-public enum GoogleSignInButtonStyle {
+public enum GoogleSignInButtonStyle: String, Identifiable, CaseIterable {
   case standard
   case wide
   case icon
+
+  public var id: String { rawValue }
 }
 
 // MARK: - Button Color Scheme
 
 /// The color schemes supported by the sign-in button.
 @available(iOS 13.0, macOS 10.15, *)
-public enum GoogleSignInButtonColorScheme {
+public enum GoogleSignInButtonColorScheme: String, Identifiable, CaseIterable {
   case dark
   case light
+
+  public var id: String { rawValue }
 }
 
 // MARK: - Button State
 
 /// The state of the sign-in button.
 @available(iOS 13.0, macOS 10.15, *)
-public enum GoogleSignInButtonState {
+public enum GoogleSignInButtonState: String, Identifiable, CaseIterable {
   case normal
   case disabled
   case pressed
+
+  public var id: String { rawValue }
 }
 
 // MARK: - Colors

--- a/Samples/Swift/DaysUntilBirthday/Shared/Views/SignInView.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Views/SignInView.swift
@@ -19,13 +19,52 @@ import GoogleSignInSwift
 
 struct SignInView: View {
   @EnvironmentObject var authViewModel: AuthenticationViewModel
+  @ObservedObject var vm = GoogleSignInButtonViewModel()
 
   var body: some View {
     VStack {
       HStack {
-        GoogleSignInButton(action: authViewModel.signIn)
-          .accessibility(hint: Text("Sign in with Google button."))
-          .padding()
+        VStack {
+          GoogleSignInButton(viewModel: vm, action: authViewModel.signIn)
+            .accessibility(hint: Text("Sign in with Google button."))
+            .padding()
+          VStack {
+            HStack {
+              Text("Button style:")
+                .padding(.leading)
+              Picker("Select button style", selection: $vm.style) {
+                ForEach(GoogleSignInButtonStyle.allCases) { style in
+                  Text(style.rawValue.capitalized)
+                    .tag(GoogleSignInButtonStyle(rawValue: style.rawValue)!)
+                }
+              }
+              Spacer()
+            }
+            HStack {
+              Text("Button color:")
+                .padding(.leading)
+              Picker("Select button color", selection: $vm.scheme) {
+                ForEach(GoogleSignInButtonColorScheme.allCases) { scheme in
+                  Text(scheme.rawValue.capitalized)
+                    .tag(GoogleSignInButtonColorScheme(rawValue: scheme.rawValue)!)
+                }
+              }
+              Spacer()
+            }
+            HStack {
+              Text("Button state:")
+                .padding(.leading)
+              Picker("Select button state", selection: $vm.state) {
+                ForEach(GoogleSignInButtonState.allCases) { state in
+                  Text(state.rawValue.capitalized)
+                    .tag(GoogleSignInButtonState(rawValue: state.rawValue)!)
+                }
+              }
+              Spacer()
+            }
+          }
+          .pickerStyle(.automatic)
+        }
       }
       Spacer()
     }

--- a/Samples/Swift/DaysUntilBirthday/Shared/Views/SignInView.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Views/SignInView.swift
@@ -32,7 +32,7 @@ struct SignInView: View {
             HStack {
               Text("Button style:")
                 .padding(.leading)
-              Picker("Select button style", selection: $vm.style) {
+              Picker("", selection: $vm.style) {
                 ForEach(GoogleSignInButtonStyle.allCases) { style in
                   Text(style.rawValue.capitalized)
                     .tag(GoogleSignInButtonStyle(rawValue: style.rawValue)!)
@@ -43,7 +43,7 @@ struct SignInView: View {
             HStack {
               Text("Button color:")
                 .padding(.leading)
-              Picker("Select button color", selection: $vm.scheme) {
+              Picker("", selection: $vm.scheme) {
                 ForEach(GoogleSignInButtonColorScheme.allCases) { scheme in
                   Text(scheme.rawValue.capitalized)
                     .tag(GoogleSignInButtonColorScheme(rawValue: scheme.rawValue)!)
@@ -54,7 +54,7 @@ struct SignInView: View {
             HStack {
               Text("Button state:")
                 .padding(.leading)
-              Picker("Select button state", selection: $vm.state) {
+              Picker("", selection: $vm.state) {
                 ForEach(GoogleSignInButtonState.allCases) { state in
                   Text(state.rawValue.capitalized)
                     .tag(GoogleSignInButtonState(rawValue: state.rawValue)!)
@@ -63,7 +63,9 @@ struct SignInView: View {
               Spacer()
             }
           }
-          .pickerStyle(.automatic)
+          #if os(iOS)
+            .pickerStyle(.automatic)
+          #endif
         }
       }
       Spacer()


### PR DESCRIPTION
This change adds a series of segmented controls to the DaysUntilBirthday sample app to show how the SwiftUI button responds to changes in styling information.

https://user-images.githubusercontent.com/4029922/166812251-30b4f98d-f568-488d-aca7-4d9eb3f0387e.mp4

Fixes #125