### PR TITLE
Rename Swift support pod

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        podspec: [GoogleSignIn.podspec, GoogleSignInSwift.podspec]
+        podspec: [GoogleSignIn.podspec, GoogleSignInSwiftSupport.podspec]
         flag: [
           "", 
           "--use-libraries", 
           "--use-static-frameworks"
         ]
         include:
-          - podspec: GoogleSignInSwift.podspec
+          - podspec: GoogleSignInSwiftSupport.podspec
             includePodspecFlag: "--include-podspecs='GoogleSignIn.podspec'"
     steps:
     - uses: actions/checkout@v2

--- a/GoogleSignInSwiftSupport.podspec
+++ b/GoogleSignInSwiftSupport.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name = 'GoogleSignInSwift'
+  s.name = 'GoogleSignInSwiftSupport'
   s.version = '6.2.0'
   s.swift_version = '4.0'
   s.summary = 'Adds Swift-focused support for Google Sign-In.'

--- a/GoogleSignInSwiftSupport.podspec
+++ b/GoogleSignInSwiftSupport.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   macos_deployment_target = '10.15' 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = macos_deployment_target
+  s.module_name = 'GoogleSignInSwift'
   s.prefix_header_file = false
   s.source_files = [
     'GoogleSignInSwift/Sources/*.swift',

--- a/Samples/Swift/DaysUntilBirthday/Podfile
+++ b/Samples/Swift/DaysUntilBirthday/Podfile
@@ -1,5 +1,5 @@
 pod 'GoogleSignIn', :path => '../../../', :testspecs => ['unit']
-pod 'GoogleSignInSwift', :path => '../../../', :testspecs => ['unit']
+pod 'GoogleSignInSwiftSupport', :path => '../../../', :testspecs => ['unit']
 project 'DaysUntilBirthdayForPod.xcodeproj'
 
 target 'DaysUntilBirthdayForPod (iOS)' do


### PR DESCRIPTION
Rename the `GoogleSignInSwift` CocoaPod to `GoogleSignInSwiftSupport` in order to avoid a naming conflict with an [existing pod](https://cocoapods.org/pods/GoogleSignInSwift).  Use [module_name](https://guides.cocoapods.org/syntax/podspec.html#module_name) in the podspec to keep Clang module names in sync with the corresponding SPM product.