### PR TITLE
Separate push notification from pull request

### DIFF
--- a/.github/workflows/pr_notification.yml
+++ b/.github/workflows/pr_notification.yml
@@ -3,10 +3,6 @@ name: GSI Chatroom PR Notification
 on:
   pull_request:
     types: [assigned, opened, ready_for_review, reopened, review_requested]
-  push:
-    branches:
-      - main
-    
 
 jobs:
   notify:

--- a/.github/workflows/push_notification.yml
+++ b/.github/workflows/push_notification.yml
@@ -1,0 +1,60 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Main Branch Push
+      run: |
+        echo "Pushing commit to main: ${{ github.event.push.head_commit.id }}"
+        echo "Pushed by: ${{ github.event.push.pusher.name }}"
+
+    - name: Push Notification to Google Chat
+      run: |
+        curl --location --request POST '${{ secrets.WEBHOOK_URL }}' \
+        --header 'Content-Type: application/json' \
+        --data-raw '{
+          "cards": [
+            {
+              "header": {
+                "title": "Push to main branch",
+                "subtitle": "${{ github.event.push.head_commit.message }}"
+              },
+              "sections": [
+                {
+                  "widgets": [
+                    {
+                      "keyValue": {
+                        "topLabel": "Repo",
+                        "content": "${{ github.event.push.repository.name }}"
+                      }
+                    },
+                    {
+                      "keyValue": {
+                        "topLabel": "Committed by",
+                        "content": "Committed by: ${{ github.event.push.head_commit.committer.username }}"
+                      }
+                    },
+                    {
+                      "buttons": [
+                        {
+                          "textButton": {
+                            "text": "Ref comparison",
+                            "onClick": {
+                              "openLink": {
+                                "url": "${{ github.event.push.compare }}"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }'


### PR DESCRIPTION
The previous `notification.yml` combined `pull_request` and `push` events. Given that the syntax for the notification inspected the event (i.e., `pull_request`), we would generate an empty notification on `push` events to the main branch because there would be nothing on the on the `pull_request` event. The simple fix is to split this notification into a separate workflow.