### PR TITLE
Prevent build errors for GoogleSignInSwift when using SPM

### DIFF
--- a/GoogleSignInSwift/Sources/GoogleSignInButton.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButton.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if !arch(arm)
+
 import SwiftUI
 import CoreGraphics
 
@@ -191,3 +193,5 @@ private extension Font {
     return CTFontManagerRegisterGraphicsFont(newFont, nil)
   }
 }
+
+#endif // !arch(arm)

--- a/GoogleSignInSwift/Sources/GoogleSignInButtonBundleExtensions.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButtonBundleExtensions.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if !arch(arm)
+
 import Foundation
 
 // MARK: - Bundle Extensions
@@ -62,3 +64,5 @@ extension Bundle {
     return bundle?.url(forResource: name, withExtension: ext)
   }
 }
+
+#endif // !arch(arm)

--- a/GoogleSignInSwift/Sources/GoogleSignInButtonStrings.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButtonStrings.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if !arch(arm)
+
 import Foundation
 
 /// A type retrieving the localized strings for the sign-in button text.
@@ -56,3 +58,5 @@ struct GoogleSignInButtonString {
     return localizedString(key: wideButtonText, text: "No translation")
   }
 }
+
+#endif // !arch(arm)

--- a/GoogleSignInSwift/Sources/GoogleSignInButtonStyling.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButtonStyling.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if !arch(arm)
+
 import SwiftUI
 
 // MARK: - Sizing Constants
@@ -280,3 +282,5 @@ struct SwiftUIButtonStyle: ButtonStyle {
       )
   }
 }
+
+#endif // !arch(arm)

--- a/GoogleSignInSwift/Sources/GoogleSignInButtonViewModel.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButtonViewModel.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if !arch(arm)
+
 import Combine
 
 /// A view model for the SwiftUI sign-in button publishing changes for the
@@ -47,3 +49,5 @@ public class GoogleSignInButtonViewModel: ObservableObject {
       self.state = state
   }
 }
+
+#endif // !arch(arm)


### PR DESCRIPTION
Because SPM does not support target-specific platform min versions, our GoogleSignInSwift target is built for both arm64 and armv7.  The armv7 stage of the build fails with missing SwiftUI symbol errors.  The armv7 slice is unnecessary as this target can only be used on iOS 13+.  This change works around the problem by preventing the armv7 build stage from doing any work.