### PR TITLE
Prevent a build error on Xcode 12 and earlier

### DIFF
--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -156,7 +156,9 @@ typedef enum {
         return ((UIWindowScene *)scene).keyWindow;
       }
     }
-  } else {
+  } else
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
+  {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_15_0
     if (@available(iOS 13, *)) {
       for (UIWindow *window in UIApplication.sharedApplication.windows) {
@@ -171,19 +173,6 @@ typedef enum {
     }
 #endif  // __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_15_0
   }
-#else // __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
-  if (@available(iOS 13, *)) {
-    for (UIWindow *window in UIApplication.sharedApplication.windows) {
-      if (window.isKeyWindow) {
-        return window;
-      }
-    }
-  } else {
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
-    return UIApplication.sharedApplication.keyWindow;
-#endif  // __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
-  }
-#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
   return nil;
 }
 

--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -148,6 +148,7 @@ typedef enum {
 
 // This method is exposed to the unit test.
 - (nullable UIWindow *)keyWindow {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
   if (@available(iOS 15, *)) {
     for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
       if ([scene isKindOfClass:[UIWindowScene class]] &&
@@ -170,6 +171,19 @@ typedef enum {
     }
 #endif  // __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_15_0
   }
+#else // __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
+  if (@available(iOS 13, *)) {
+    for (UIWindow *window in UIApplication.sharedApplication.windows) {
+      if (window.isKeyWindow) {
+        return window;
+      }
+    }
+  } else {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
+    return UIApplication.sharedApplication.keyWindow;
+#endif  // __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
+  }
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
   return nil;
 }
 

--- a/GoogleSignIn/Tests/Unit/GIDEMMErrorHandlerTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMErrorHandlerTest.m
@@ -494,12 +494,15 @@ NS_ASSUME_NONNULL_BEGIN
                    selector:@selector(sharedApplication)
             isClassSelector:YES
                   withBlock:^{ return mockApplication; }];
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
   if (@available(iOS 15, *)) {
     UIWindowScene *mockWindowScene = OCMClassMock([UIWindowScene class]);
     OCMStub(mockApplication.connectedScenes).andReturn(@[mockWindowScene]);
     OCMStub(mockWindowScene.activationState).andReturn(UISceneActivationStateForegroundActive);
     OCMStub(mockWindowScene.keyWindow).andReturn(mockKeyWindow);
-  } else {
+  } else
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
+  {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_15_0
     if (@available(iOS 13, *)) {
       OCMStub(mockApplication.windows).andReturn(@[mockKeyWindow]);


### PR DESCRIPTION
The `keyWindow` property of `UIWindowScene` was introduced in iOS 15.