### PR TITLE
Run tests on macOS 10.15 with Xcode 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,9 +36,10 @@ jobs:
            ${{ matrix.includePodspecFlag }}  ${{ matrix.flag }}
 
   spm-build-test:
-    runs-on: macOS-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-latest, macos-10.15]
         sdk: ['macosx', 'iphonesimulator']
         include:
           - sdk: 'macosx'
@@ -46,9 +47,6 @@ jobs:
           - sdk: 'iphonesimulator'
             destination: '"platform=iOS Simulator,name=iPhone 11"'
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '12.5.1'
     - uses: actions/checkout@v2
     - name: Build unit test target
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,9 @@ jobs:
           - sdk: 'iphonesimulator'
             destination: '"platform=iOS Simulator,name=iPhone 11"'
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '12.5.1'
     - uses: actions/checkout@v2
     - name: Build unit test target
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,11 @@ on:
 jobs:
 
   pod-lib-lint:
-    runs-on: macOS-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [macos-latest, macos-10.15]
         podspec: [GoogleSignIn.podspec, GoogleSignInSwiftSupport.podspec]
         flag: [
           "", 
@@ -38,6 +40,7 @@ jobs:
   spm-build-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, macos-10.15]
         sdk: ['macosx', 'iphonesimulator']


### PR DESCRIPTION
Extend our CI test coverage to include macOS 10.15 and Xcode 12.

Some pod tests are failing due to [transient CocoaPods CDN errors](https://github.com/CocoaPods/CocoaPods/issues/11355 ).

The macOS-10.15 tests that are building for iOS are failing due to a build error that will be addressed with #158.