### PR TITLE
Remove __has_include from GIDFakeMainBundle

### DIFF
--- a/GoogleSignIn/Tests/Unit/GIDFakeMainBundle.m
+++ b/GoogleSignIn/Tests/Unit/GIDFakeMainBundle.m
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-#if __has_include(<UIKit/UIKit.h>)
-#import <UIKit/UIKit.h>
-#endif
-
 #import "GoogleSignIn/Tests/Unit/GIDFakeMainBundle.h"
 
 #import <GoogleUtilities/GULSwizzler.h>


### PR DESCRIPTION
This check is not needed as the test target will still build and the tests will pass without it.