### PR TITLE
Re-enable EMM unit tests for SPM

### DIFF
--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -162,7 +162,7 @@ typedef enum {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_15_0
     if (@available(iOS 13, *)) {
       for (UIWindow *window in UIApplication.sharedApplication.windows) {
-        if (window.isKeyWindow) {
+        if (window.keyWindow) {
           return window;
         }
       }

--- a/GoogleSignIn/Sources/GIDEMMErrorHandler.m
+++ b/GoogleSignIn/Sources/GIDEMMErrorHandler.m
@@ -162,7 +162,7 @@ typedef enum {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_15_0
     if (@available(iOS 13, *)) {
       for (UIWindow *window in UIApplication.sharedApplication.windows) {
-        if (window.keyWindow) {
+        if (window.isKeyWindow) {
           return window;
         }
       }

--- a/GoogleSignIn/Tests/Unit/GIDEMMErrorHandlerTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMErrorHandlerTest.m
@@ -152,9 +152,6 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertNil(_presentedViewController);
 }
 
-// TODO(petea): Figure out why we have a race condition for the first of these to run.
-#if !SWIFT_PACKAGE
-
 // Verifies that the handler handles general EMM error with user tapping 'OK'.
 - (void)testGeneralEMMErrorOK {
   __block BOOL completionCalled = NO;
@@ -520,8 +517,6 @@ NS_ASSUME_NONNULL_BEGIN
                      selector:@selector(sharedApplication)
               isClassSelector:YES];
 }
-
-#endif
 
 @end
 


### PR DESCRIPTION
This subset of the `GIDEMMErrorHandler` unit tests had been failing randomly with a mysterious race condition.  It seems to no longer be an issue for whatever reason.

Now, the [one SPM test failure](https://github.com/google/GoogleSignIn-iOS/runs/6634642853?check_suite_focus=true#step:4:126) is a pre-existing issue, matching the behavior of the `pod lib lint` tests.
