### PR TITLE
Rename callback blocks to completion to support Swift async and await

### DIFF
--- a/GoogleSignIn/Sources/GIDAuthentication.m
+++ b/GoogleSignIn/Sources/GIDAuthentication.m
@@ -219,17 +219,17 @@ static NSString *const kNewIOSSystemName = @"iOS";
   return authorization;
 }
 
-- (void)doWithFreshTokens:(GIDAuthenticationAction)action {
+- (void)doWithFreshTokens:(GIDAuthenticationCompletion)completion {
   if (!([self.accessTokenExpirationDate timeIntervalSinceNow] < kMinimalTimeToExpire ||
       (self.idToken && [self.idTokenExpirationDate timeIntervalSinceNow] < kMinimalTimeToExpire))) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      action(self, nil);
+      completion(self, nil);
     });
     return;
   }
   @synchronized (_authenticationHandlerQueue) {
     // Push the handler into the callback queue.
-    [_authenticationHandlerQueue addObject:[action copy]];
+    [_authenticationHandlerQueue addObject:[completion copy]];
     if (_authenticationHandlerQueue.count > 1) {
       // This is not the first handler in the queue, no fetch is needed.
       return;
@@ -277,9 +277,9 @@ static NSString *const kNewIOSSystemName = @"iOS";
         authenticationHandlerQueue = [self->_authenticationHandlerQueue copy];
         [self->_authenticationHandlerQueue removeAllObjects];
       }
-      for (GIDAuthenticationAction action in authenticationHandlerQueue) {
+      for (GIDAuthenticationCompletion completion in authenticationHandlerQueue) {
         dispatch_async(dispatch_get_main_queue(), ^{
-          action(error ? nil : self, error);
+          completion(error ? nil : self, error);
         });
       }
     }];
@@ -289,9 +289,9 @@ static NSString *const kNewIOSSystemName = @"iOS";
       authenticationHandlerQueue = [self->_authenticationHandlerQueue copy];
       [self->_authenticationHandlerQueue removeAllObjects];
     }
-    for (GIDAuthenticationAction action in authenticationHandlerQueue) {
+    for (GIDAuthenticationCompletion completion in authenticationHandlerQueue) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        action(error ? nil : self, error);
+        completion(error ? nil : self, error);
       });
     }
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -187,8 +187,8 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   return [authState isAuthorized];
 }
 
-- (void)restorePreviousSignInWithCallback:(nullable GIDSignInCallback)callback {
-  [self signInWithOptions:[GIDSignInInternalOptions silentOptionsWithCallback:callback]];
+- (void)restorePreviousSignInWithCompletion:(nullable GIDSignInCompletion)completion {
+  [self signInWithOptions:[GIDSignInInternalOptions silentOptionsWithCompletion:completion]];
 }
 
 - (BOOL)restorePreviousSignInNoRefresh {
@@ -217,13 +217,13 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
-                       callback:(nullable GIDSignInCallback)callback {
+                     completion:(nullable GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options =
       [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
                                        presentingViewController:presentingViewController
                                                       loginHint:hint
-                                                   addScopesFlow:NO
-                                                       callback:callback];
+                                                  addScopesFlow:NO
+                                                     completion:completion];
   [self signInWithOptions:options];
 }
 
@@ -231,38 +231,38 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
                additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                       callback:(nullable GIDSignInCallback)callback {
+                     completion:(nullable GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options =
     [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
                                      presentingViewController:presentingViewController
                                                     loginHint:hint
                                                 addScopesFlow:NO
                                                        scopes:additionalScopes
-                                                     callback:callback];
+                                                   completion:completion];
   [self signInWithOptions:options];
 }
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
-                       callback:(nullable GIDSignInCallback)callback {
+                     completion:(nullable GIDSignInCompletion)completion {
   [self signInWithConfiguration:configuration
        presentingViewController:presentingViewController
                            hint:nil
-                       callback:callback];
+                     completion:completion];
 }
 
 - (void)addScopes:(NSArray<NSString *> *)scopes
     presentingViewController:(UIViewController *)presentingViewController
-                    callback:(nullable GIDSignInCallback)callback {
+                  completion:(nullable GIDSignInCompletion)completion {
   // A currentUser must be available in order to complete this flow.
   if (!self.currentUser) {
     // No currentUser is set, notify callback of failure.
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeNoCurrentUser
                                      userInfo:nil];
-    if (callback) {
+    if (completion) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        callback(nil, error);
+        completion(nil, error);
       });
     }
     return;
@@ -278,7 +278,7 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
                                        presentingViewController:presentingViewController
                                                       loginHint:self.currentUser.profile.email
                                                   addScopesFlow:YES
-                                                       callback:callback];
+                                                     completion:completion];
 
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
@@ -290,9 +290,9 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeScopesAlreadyGranted
                                      userInfo:nil];
-    if (callback) {
+    if (completion) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        callback(nil, error);
+        completion(nil, error);
       });
     }
     return;
@@ -310,52 +310,52 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
                            hint:(nullable NSString *)hint
-                       callback:(nullable GIDSignInCallback)callback {
+                     completion:(nullable GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options =
       [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
                                                presentingWindow:presentingWindow
                                                       loginHint:hint
-                                                   addScopesFlow:NO
-                                                       callback:callback];
+                                                  addScopesFlow:NO
+                                                     completion:completion];
   [self signInWithOptions:options];
 }
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
-                       callback:(nullable GIDSignInCallback)callback {
+                     completion:(nullable GIDSignInCompletion)completion {
   [self signInWithConfiguration:configuration
                presentingWindow:presentingWindow
                            hint:nil
-                       callback:callback];
+                     completion:completion];
 }
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
                            hint:(nullable NSString *)hint
                additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                       callback:(nullable GIDSignInCallback)callback {
+                     completion:(nullable GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options =
     [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
                                              presentingWindow:presentingWindow
                                                     loginHint:hint
                                                 addScopesFlow:NO
                                                        scopes:additionalScopes
-                                                     callback:callback];
+                                                   completion:completion];
   [self signInWithOptions:options];
 }
 
 - (void)addScopes:(NSArray<NSString *> *)scopes
-            presentingWindow:(NSWindow *)presentingWindow
-                    callback:(nullable GIDSignInCallback)callback {
+ presentingWindow:(NSWindow *)presentingWindow
+       completion:(nullable GIDSignInCompletion)completion {
   // A currentUser must be available in order to complete this flow.
   if (!self.currentUser) {
     // No currentUser is set, notify callback of failure.
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeNoCurrentUser
                                      userInfo:nil];
-    if (callback) {
+    if (completion) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        callback(nil, error);
+        completion(nil, error);
       });
     }
     return;
@@ -371,7 +371,7 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
                                                presentingWindow:presentingWindow
                                                       loginHint:self.currentUser.profile.email
                                                   addScopesFlow:YES
-                                                       callback:callback];
+                                                     completion:completion];
 
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
@@ -383,9 +383,9 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeScopesAlreadyGranted
                                      userInfo:nil];
-    if (callback) {
+    if (completion) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        callback(nil, error);
+        completion(nil, error);
       });
     }
     return;
@@ -411,7 +411,7 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   [self removeAllKeychainEntries];
 }
 
-- (void)disconnectWithCallback:(nullable GIDDisconnectCallback)callback {
+- (void)disconnectWithCompletion:(nullable GIDDisconnectCompletion)completion {
   GIDGoogleUser *user = _currentUser;
   OIDAuthState *authState = user.authentication.authState;
   if (!authState) {
@@ -428,9 +428,9 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   if (!token) {
     [self signOut];
     // Nothing to do here, consider the operation successful.
-    if (callback) {
+    if (completion) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        callback(nil);
+        completion(nil);
       });
     }
     return;
@@ -453,9 +453,9 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
     if (!error) {
       [self signOut];
     }
-    if (callback) {
+    if (completion) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        callback(error);
+        completion(error);
       });
     }
   }];
@@ -538,10 +538,10 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
       if (error) {
         [self authenticateWithOptions:options];
       } else {
-        if (options.callback) {
+        if (options.completion) {
           self->_currentOptions = nil;
           dispatch_async(dispatch_get_main_queue(), ^{
-            options.callback(self->_currentUser, nil);
+            options.completion(self->_currentUser, nil);
           });
         }
       }
@@ -707,10 +707,10 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeHasNoAuthInKeychain
                                      userInfo:nil];
-    if (options.callback) {
+    if (options.completion) {
       _currentOptions = nil;
       dispatch_async(dispatch_get_main_queue(), ^{
-        options.callback(nil, error);
+        options.completion(nil, error);
       });
     }
     return;
@@ -881,11 +881,11 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   __weak GIDAuthFlow *weakAuthFlow = authFlow;
   [authFlow addCallback:^() {
     GIDAuthFlow *handlerAuthFlow = weakAuthFlow;
-    if (self->_currentOptions.callback) {
-      GIDSignInCallback callback = self->_currentOptions.callback;
+    if (self->_currentOptions.completion) {
+      GIDSignInCompletion completion = self->_currentOptions.completion;
       self->_currentOptions = nil;
       dispatch_async(dispatch_get_main_queue(), ^{
-        callback(self->_currentUser, handlerAuthFlow.error);
+        completion(self->_currentUser, handlerAuthFlow.error);
       });
     }
   }];

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.h
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.h
@@ -54,8 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly, weak, nullable) NSWindow *presentingWindow;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 
-/// The callback block to be called at the completion of the flow.
-@property(nonatomic, readonly, nullable) GIDSignInCallback callback;
+/// The completion block to be called at the completion of the flow.
+@property(nonatomic, readonly, nullable) GIDSignInCompletion completion;
 
 /// The scopes to be used during the flow.
 @property(nonatomic, copy, nullable) NSArray<NSString *> *scopes;
@@ -69,32 +69,32 @@ NS_ASSUME_NONNULL_BEGIN
                        presentingViewController:(nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
-                                       callback:(nullable GIDSignInCallback)callback;
+                                     completion:(nullable GIDSignInCompletion)completion;
 
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                        presentingViewController:(nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
-                                       callback:(nullable GIDSignInCallback)callback;
+                                     completion:(nullable GIDSignInCompletion)completion;
 
 #elif TARGET_OS_OSX
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                                presentingWindow:(nullable NSWindow *)presentingWindow
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
-                                       callback:(nullable GIDSignInCallback)callback;
+                                     completion:(nullable GIDSignInCompletion)completion;
 
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                                presentingWindow:(nullable NSWindow *)presentingWindow
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
-                                       callback:(nullable GIDSignInCallback)callback;
+                                     completion:(nullable GIDSignInCompletion)completion;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 
 /// Creates the options to sign in silently.
-+ (instancetype)silentOptionsWithCallback:(GIDSignInCallback)callback;
++ (instancetype)silentOptionsWithCompletion:(GIDSignInCompletion)completion;
 
 /// Creates options with the same values as the receiver, except for the "extra parameters", and
 /// continuation flag, which are replaced by the arguments passed to this method.

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.m
@@ -31,14 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
-                                       callback:(nullable GIDSignInCallback)callback {
+                                     completion:(nullable GIDSignInCompletion)completion {
 #elif TARGET_OS_OSX
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                                presentingWindow:(nullable NSWindow *)presentingWindow
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
-                                       callback:(nullable GIDSignInCallback)callback {
+                                     completion:(nullable GIDSignInCompletion)completion {
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
   
   GIDSignInInternalOptions *options = [[GIDSignInInternalOptions alloc] init];
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_presentingWindow = presentingWindow;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
     options->_loginHint = loginHint;
-    options->_callback = callback;
+    options->_completion = completion;
     options->_scopes = [GIDScopes scopesWithBasicProfile:scopes];
   }
   return options;
@@ -64,13 +64,13 @@ NS_ASSUME_NONNULL_BEGIN
                        presentingViewController:(nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
-                                       callback:(nullable GIDSignInCallback)callback {
+                                     completion:(nullable GIDSignInCompletion)completion {
 #elif TARGET_OS_OSX
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                                presentingWindow:(nullable NSWindow *)presentingWindow
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
-                                       callback:(nullable GIDSignInCallback)callback {
+                                     completion:(nullable GIDSignInCompletion)completion {
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
     GIDSignInInternalOptions *options = [self defaultOptionsWithConfiguration:configuration
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
@@ -81,11 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
                                                                     loginHint:loginHint
                                                                 addScopesFlow:addScopesFlow
                                                                        scopes:@[]
-                                                                     callback:callback];
+                                                                   completion:completion];
   return options;
 }
 
-+ (instancetype)silentOptionsWithCallback:(GIDSignInCallback)callback {
++ (instancetype)silentOptionsWithCompletion:(GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options = [self defaultOptionsWithConfiguration:nil
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                                    presentingViewController:nil
@@ -93,8 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                            presentingWindow:nil
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                                                   loginHint:nil
-                                                               addScopesFlow:NO
-                                                                   callback:callback];
+                                                              addScopesFlow:NO
+                                                                 completion:completion];
   if (options) {
     options->_interactive = NO;
   }
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_presentingWindow = _presentingWindow;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
     options->_loginHint = _loginHint;
-    options->_callback = _callback;
+    options->_completion = _completion;
     options->_scopes = _scopes;
     options->_extraParams = [extraParams copy];
   }

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h
@@ -28,10 +28,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// A callback block that takes a `GIDAuthentication` or an error if the attempt to refresh tokens
+/// A completion block that takes a `GIDAuthentication` or an error if the attempt to refresh tokens
 /// was unsuccessful.
-typedef void (^GIDAuthenticationAction)(GIDAuthentication *_Nullable authentication,
-                                        NSError *_Nullable error);
+typedef void (^GIDAuthenticationCompletion)(GIDAuthentication *_Nullable authentication,
+                                            NSError *_Nullable error);
 
 /// This class represents the OAuth 2.0 entities needed for sign-in.
 @interface GIDAuthentication : NSObject <NSSecureCoding>
@@ -64,9 +64,10 @@ typedef void (^GIDAuthenticationAction)(GIDAuthentication *_Nullable authenticat
 /// Get a valid access token and a valid ID token, refreshing them first if they have expired or are
 /// about to expire.
 ///
-/// @param action A callback block that takes a `GIDAuthentication` or an error if the attempt to
-///     refresh tokens was unsuccessful.  The block will be called asynchronously on the main queue.
-- (void)doWithFreshTokens:(GIDAuthenticationAction)action;
+/// @param completion A completion block that takes a `GIDAuthentication` or an error if the attempt
+///     to refresh tokens was unsuccessful.  The block will be called asynchronously on the main
+///     queue.
+- (void)doWithFreshTokens:(GIDAuthenticationCompletion)completion;
 
 @end
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -50,12 +50,12 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
   kGIDSignInErrorCodeScopesAlreadyGranted = -8,
 };
 
-/// Represents a callback block that takes a `GIDGoogleUser` on success or an error if the operation
+/// Represents a completion block that takes a `GIDGoogleUser` on success or an error if the operation
 /// was unsuccessful.
-typedef void (^GIDSignInCallback)(GIDGoogleUser *_Nullable user, NSError *_Nullable error);
+typedef void (^GIDSignInCompletion)(GIDGoogleUser *_Nullable user, NSError *_Nullable error);
 
-/// Represents a callback block that takes an error if the operation was unsuccessful.
-typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
+/// Represents a completion block that takes an error if the operation was unsuccessful.
+typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
 
 /// This class signs the user in with Google.
 ///
@@ -91,9 +91,9 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 
 /// Attempts to restore a previously authenticated user without interaction.
 ///
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
-- (void)restorePreviousSignInWithCallback:(nullable GIDSignInCallback)callback;
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)restorePreviousSignInWithCompletion:(nullable GIDSignInCompletion)completion;
 
 /// Marks current user as being in the signed out state.
 - (void)signOut;
@@ -101,35 +101,35 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 /// Disconnects the current user from the app and revokes previous authentication. If the operation
 /// succeeds, the OAuth 2.0 token is also removed from keychain.
 ///
-/// @param callback The optional `GIDDisconnectCallback` block that is called on completion.  This
-///     block will be called asynchronously on the main queue.
-- (void)disconnectWithCallback:(nullable GIDDisconnectCallback)callback;
+/// @param completion The optional `GIDDisconnectCompletion` block that is called on completion.
+///     This block will be called asynchronously on the main queue.
+- (void)disconnectWithCompletion:(nullable GIDDisconnectCompletion)completion;
 
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 /// Starts an interactive sign-in flow on iOS using the provided configuration.
 ///
-/// The callback will be called at the end of this process.  Any saved sign-in state will be
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
 ///     iOS 9 and 10 and to supply `presentationContextProvider` for `ASWebAuthenticationSession` on
 ///     iOS 13+.
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
-                       callback:(nullable GIDSignInCallback)callback
+                     completion:(nullable GIDSignInCompletion)completion
     NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
-/// Starts an interactive sign-in flow  on iOS using the provided configuration and a login hint.
+/// Starts an interactive sign-in flow on iOS using the provided configuration and a login hint.
 ///
-/// The callback will be called at the end of this process.  Any saved sign-in state will be
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
@@ -137,20 +137,20 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 ///     iOS 13+.
 /// @param hint An optional hint for the authorization server, for example the user's ID or email
 ///     address, to be prefilled if possible.
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
-                       callback:(nullable GIDSignInCallback)callback
+                     completion:(nullable GIDSignInCompletion)completion
     NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
 /// Starts an interactive sign-in flow on iOS using the provided configuration and a login hint.
 ///
-/// The callback will be called at the end of this process.  Any saved sign-in state will be
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
@@ -158,98 +158,98 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 /// @param hint An optional hint for the authorization server, for example the user's ID or email
 ///     address, to be prefilled if possible.
 /// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
                additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                       callback:(nullable GIDSignInCallback)callback;
+                     completion:(nullable GIDSignInCompletion)completion;
 
 /// Starts an interactive consent flow on iOS to add scopes to the current user's grants.
 ///
-/// The callback will be called at the end of this process.  If successful, a new `GIDGoogleUser`
+/// The completion will be called at the end of this process.  If successful, a new `GIDGoogleUser`
 /// instance will be returned reflecting the new scopes and saved sign-in state will be updated.
 ///
 /// @param scopes The scopes to ask the user to consent to.
 /// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
 ///     iOS 9 and 10 and to supply `presentationContextProvider` for `ASWebAuthenticationSession` on
 ///     iOS 13+.
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
 - (void)addScopes:(NSArray<NSString *> *)scopes
     presentingViewController:(UIViewController *)presentingViewController
-                    callback:(nullable GIDSignInCallback)callback
+                  completion:(nullable GIDSignInCompletion)completion
     NS_EXTENSION_UNAVAILABLE("The add scopes flow is not supported in App Extensions."); 
 
 #elif TARGET_OS_OSX
 /// Starts an interactive sign-in flow on macOS using the provided configuration.
 ///
-/// The callback will be called at the end of this process.  Any saved sign-in state will be
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
-                       callback:(nullable GIDSignInCallback)callback;
+                     completion:(nullable GIDSignInCompletion)completion;
 
 /// Starts an interactive sign-in flow on macOS using the provided configuration and a login hint.
 ///
-/// The callback will be called at the end of this process.  Any saved sign-in state will be
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
 /// @param hint An optional hint for the authorization server, for example the user's ID or email
 ///     address, to be prefilled if possible.
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
                            hint:(nullable NSString *)hint
-                       callback:(nullable GIDSignInCallback)callback;
+                     completion:(nullable GIDSignInCompletion)completion;
 
 /// Starts an interactive sign-in flow on macOS using the provided configuration and a login hint.
 ///
-/// The callback will be called at the end of this process.  Any saved sign-in state will be
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
 /// @param hint An optional hint for the authorization server, for example the user's ID or email
 ///     address, to be prefilled if possible.
 /// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
                            hint:(nullable NSString *)hint
                additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                       callback:(nullable GIDSignInCallback)callback;
+                     completion:(nullable GIDSignInCompletion)completion;
 
 /// Starts an interactive consent flow on macOS to add scopes to the current user's grants.
 ///
-/// The callback will be called at the end of this process.  If successful, a new `GIDGoogleUser`
+/// The completion will be called at the end of this process.  If successful, a new `GIDGoogleUser`
 /// instance will be returned reflecting the new scopes and saved sign-in state will be updated.
 ///
 /// @param scopes An array of scopes to ask the user to consent to.
 /// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
-/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
-///     called asynchronously on the main queue.
+/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
 - (void)addScopes:(NSArray<NSString *> *)scopes
-       presentingWindow:(NSWindow *)presentingWindow
-               callback:(nullable GIDSignInCallback)callback;
+ presentingWindow:(NSWindow *)presentingWindow
+       completion:(nullable GIDSignInCompletion)completion;
 
 #endif
 

--- a/GoogleSignIn/Tests/Unit/GIDSignInInternalOptionsTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInInternalOptionsTest.m
@@ -37,7 +37,7 @@
   id presentingWindow = OCMStrictClassMock([NSWindow class]);
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
   NSString *loginHint = @"login_hint";
-  GIDSignInCallback callback = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {};
+  GIDSignInCompletion completion = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {};
   
   GIDSignInInternalOptions *options =
       [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
@@ -47,8 +47,8 @@
                                                presentingWindow:presentingWindow
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                                       loginHint:loginHint
-                                                   addScopesFlow:NO
-                                                       callback:callback];
+                                                  addScopesFlow:NO
+                                                     completion:completion];
   XCTAssertTrue(options.interactive);
   XCTAssertFalse(options.continuation);
   XCTAssertFalse(options.addScopesFlow);
@@ -63,12 +63,13 @@
 }
 
 - (void)testSilentOptions {
-  GIDSignInCallback callback = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {};
-  GIDSignInInternalOptions *options = [GIDSignInInternalOptions silentOptionsWithCallback:callback];
+  GIDSignInCompletion completion = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {};
+  GIDSignInInternalOptions *options = [GIDSignInInternalOptions
+                                       silentOptionsWithCompletion:completion];
   XCTAssertFalse(options.interactive);
   XCTAssertFalse(options.continuation);
   XCTAssertNil(options.extraParams);
-  XCTAssertEqual(options.callback, callback);
+  XCTAssertEqual(options.completion, completion);
 }
 
 @end

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -217,7 +217,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   NSError *_authError;
 
   // Whether callback block has been called.
-  BOOL _callbackCalled;
+  BOOL _completionCalled;
 
   // Fake fetcher service to emulate network requests.
   GIDFakeFetcherService *_fetcherService;
@@ -240,8 +240,8 @@ static void *kTestObserverContext = &kTestObserverContext;
   // The login hint to be used when testing |GIDSignIn|.
   NSString *_hint;
 
-  // The callback to be used when testing |GIDSignIn|.
-  GIDSignInCallback _callback;
+  // The completion to be used when testing |GIDSignIn|.
+  GIDSignInCompletion _completion;
 
   // The saved authorization request.
   OIDAuthorizationRequest *_savedAuthorizationRequest;
@@ -283,7 +283,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   _saveAuthorizationReturnValue = YES;
 
   // States
-  _callbackCalled = NO;
+  _completionCalled = NO;
   _keychainSaved = NO;
   _keychainRemoved = NO;
   _changedKeyPaths = [[NSMutableSet alloc] init];
@@ -346,13 +346,13 @@ static void *kTestObserverContext = &kTestObserverContext;
   _hint = nil;
 
   __weak GIDSignInTest *weakSelf = self;
-  _callback = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+  _completion = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
     GIDSignInTest *strongSelf = weakSelf;
     if (!user) {
       XCTAssertNotNil(error, @"should have an error if user is nil");
     }
-    XCTAssertFalse(strongSelf->_callbackCalled, @"callback already called");
-    strongSelf->_callbackCalled = YES;
+    XCTAssertFalse(strongSelf->_completionCalled, @"callback already called");
+    strongSelf->_completionCalled = YES;
     strongSelf->_authError = error;
   };
 
@@ -434,7 +434,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [_authorization verify];
   [_authState verify];
   XCTAssertFalse(_keychainRemoved, @"should not remove keychain");
-  XCTAssertFalse(_callbackCalled, @"should not call delegate");
+  XCTAssertFalse(_completionCalled, @"should not call delegate");
   XCTAssertNil(_authError, @"should have no error");
 }
 
@@ -445,19 +445,19 @@ static void *kTestObserverContext = &kTestObserverContext;
   [_authorization verify];
   [_authState verify];
   XCTAssertFalse(_keychainRemoved, @"should not remove keychain");
-  XCTAssertFalse(_callbackCalled, @"should not call delegate");
+  XCTAssertFalse(_completionCalled, @"should not call delegate");
 }
 
 - (void)testRestorePreviousSignInWhenSignedOut {
   [[[_authorization expect] andReturn:_authState] authState];
   [[[_authState expect] andReturnValue:[NSNumber numberWithBool:NO]] isAuthorized];
-  _callbackCalled = NO;
+  _completionCalled = NO;
   _authError = nil;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Callback should be called."];
 
-  [_signIn restorePreviousSignInWithCallback:^(GIDGoogleUser * _Nullable user,
-                                               NSError * _Nullable error) {
+  [_signIn restorePreviousSignInWithCompletion:^(GIDGoogleUser * _Nullable user,
+                                                 NSError * _Nullable error) {
     [expectation fulfill];
     XCTAssertNotNil(error, @"error should not have been nil");
     XCTAssertEqual(error.domain,
@@ -670,7 +670,7 @@ static void *kTestObserverContext = &kTestObserverContext;
                      oldAccessToken:NO
                         modalCancel:NO];
   [self waitForExpectationsWithTimeout:1 handler:nil];
-  XCTAssertTrue(_callbackCalled, @"should call delegate");
+  XCTAssertTrue(_completionCalled, @"should call delegate");
   XCTAssertEqual(_authError.code, kGIDSignInErrorCodeCanceled);
 }
 
@@ -684,7 +684,7 @@ static void *kTestObserverContext = &kTestObserverContext;
                      oldAccessToken:NO
                         modalCancel:YES];
   [self waitForExpectationsWithTimeout:1 handler:nil];
-  XCTAssertTrue(_callbackCalled, @"should call delegate");
+  XCTAssertTrue(_completionCalled, @"should call delegate");
   XCTAssertEqual(_authError.code, kGIDSignInErrorCodeCanceled);
 }
 
@@ -699,7 +699,7 @@ static void *kTestObserverContext = &kTestObserverContext;
                         modalCancel:NO];
   [self waitForExpectationsWithTimeout:1 handler:nil];
   XCTAssertFalse(_keychainSaved, @"should save to keychain");
-  XCTAssertTrue(_callbackCalled, @"should call delegate");
+  XCTAssertTrue(_completionCalled, @"should call delegate");
   XCTAssertEqualObjects(_authError.domain, kGIDSignInErrorDomain);
   XCTAssertEqual(_authError.code, kGIDSignInErrorCodeKeychain);
 }
@@ -731,13 +731,13 @@ static void *kTestObserverContext = &kTestObserverContext;
   XCTAssertFalse([_signIn handleURL:[NSURL URLWithString:kWrongSchemeURL]],
                  @"should not handle URL");
   XCTAssertFalse(_keychainSaved, @"should not save to keychain");
-  XCTAssertFalse(_callbackCalled, @"should not call delegate");
+  XCTAssertFalse(_completionCalled, @"should not call delegate");
 }
 
 - (void)testNotHandleWrongPath {
   XCTAssertFalse([_signIn handleURL:[NSURL URLWithString:kWrongPathURL]], @"should not handle URL");
   XCTAssertFalse(_keychainSaved, @"should not save to keychain");
-  XCTAssertFalse(_callbackCalled, @"should not call delegate");
+  XCTAssertFalse(_completionCalled, @"should not call delegate");
 }
 
 #pragma mark - Tests - disconnectWithCallback:
@@ -750,7 +750,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [[[_authorization expect] andReturn:_fetcherService] fetcherService];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Callback called with nil error"];
-  [_signIn disconnectWithCallback:^(NSError * _Nullable error) {
+  [_signIn disconnectWithCompletion:^(NSError * _Nullable error) {
     if (error == nil) {
       [expectation fulfill];
     }
@@ -767,7 +767,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [[[_authState expect] andReturn:_tokenResponse] lastTokenResponse];
   [[[_tokenResponse expect] andReturn:kAccessToken] accessToken];
   [[[_authorization expect] andReturn:_fetcherService] fetcherService];
-  [_signIn disconnectWithCallback:nil];
+  [_signIn disconnectWithCompletion:nil];
   [self verifyAndRevokeToken:kAccessToken hasCallback:NO];
   [_authorization verify];
   [_authState verify];
@@ -784,7 +784,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [[[_authorization expect] andReturn:_fetcherService] fetcherService];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Callback called with nil error"];
-  [_signIn disconnectWithCallback:^(NSError * _Nullable error) {
+  [_signIn disconnectWithCompletion:^(NSError * _Nullable error) {
     if (error == nil) {
       [expectation fulfill];
     }
@@ -803,7 +803,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [[[_authorization expect] andReturn:_fetcherService] fetcherService];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Callback called with an error"];
-  [_signIn disconnectWithCallback:^(NSError * _Nullable error) {
+  [_signIn disconnectWithCompletion:^(NSError * _Nullable error) {
     if (error != nil) {
       [expectation fulfill];
     }
@@ -824,7 +824,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [[[_authState expect] andReturn:_tokenResponse] lastTokenResponse];
   [[[_tokenResponse expect] andReturn:kAccessToken] accessToken];
   [[[_authorization expect] andReturn:_fetcherService] fetcherService];
-  [_signIn disconnectWithCallback:nil];
+  [_signIn disconnectWithCompletion:nil];
   XCTAssertTrue([self isFetcherStarted], @"should start fetching");
   // Emulate result back from server.
   NSError *error = [self error];
@@ -844,7 +844,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [[[_tokenResponse expect] andReturn:nil] refreshToken];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Callback called with nil error"];
-  [_signIn disconnectWithCallback:^(NSError * _Nullable error) {
+  [_signIn disconnectWithCompletion:^(NSError * _Nullable error) {
     if (error == nil) {
       [expectation fulfill];
     }
@@ -864,7 +864,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [[[_tokenResponse expect] andReturn:nil] accessToken];
   [[[_authState expect] andReturn:_tokenResponse] lastTokenResponse];
   [[[_tokenResponse expect] andReturn:nil] refreshToken];
-  [_signIn disconnectWithCallback:nil];
+  [_signIn disconnectWithCompletion:nil];
   XCTAssertFalse([self isFetcherStarted], @"should not fetch");
   XCTAssertTrue(_keychainRemoved, @"keychain should be removed");
   [_authorization verify];
@@ -887,7 +887,7 @@ static void *kTestObserverContext = &kTestObserverContext;
                                   presentingWindow:_presentingWindow
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                               hint:_hint
-                                          callback:_callback]);
+                                        completion:_completion]);
 }
 
 - (void)testClientIDMissingException {
@@ -903,7 +903,7 @@ static void *kTestObserverContext = &kTestObserverContext;
 #elif TARGET_OS_OSX
                     presentingWindow:_presentingWindow
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
-                            callback:nil];
+                          completion:nil];
   } @catch (NSException *exception) {
     threw = YES;
     XCTAssertEqualObjects(exception.description,
@@ -924,7 +924,7 @@ static void *kTestObserverContext = &kTestObserverContext;
                     presentingWindow:_presentingWindow
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                 hint:_hint
-                            callback:_callback];
+                          completion:_completion];
   } @catch (NSException *exception) {
     threw = YES;
     XCTAssertEqualObjects(exception.description,
@@ -1040,7 +1040,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   [self waitForExpectationsWithTimeout:1 handler:nil];
 
   XCTAssertFalse(_keychainSaved, @"should not save to keychain");
-  XCTAssertTrue(_callbackCalled, @"should call delegate");
+  XCTAssertTrue(_completionCalled, @"should call delegate");
   XCTAssertNotNil(_authError, @"should have error");
   XCTAssertEqualObjects(_authError.domain, kGIDSignInErrorDomain);
   XCTAssertEqual(_authError.code, kGIDSignInErrorCodeEMM);
@@ -1079,7 +1079,7 @@ static void *kTestObserverContext = &kTestObserverContext;
 
   [_authentication verify];
   XCTAssertFalse(_keychainSaved, @"should not save to keychain");
-  XCTAssertTrue(_callbackCalled, @"should call delegate");
+  XCTAssertTrue(_completionCalled, @"should call delegate");
   XCTAssertNotNil(_authError, @"should have error");
   XCTAssertEqualObjects(_authError.domain, kGIDSignInErrorDomain);
   XCTAssertEqual(_authError.code, kGIDSignInErrorCodeEMM);
@@ -1220,13 +1220,13 @@ static void *kTestObserverContext = &kTestObserverContext;
     }
   } else {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Callback called"];
-    GIDSignInCallback callback = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+    GIDSignInCompletion completion = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
       [expectation fulfill];
       if (!user) {
         XCTAssertNotNil(error, @"should have an error if user is nil");
       }
-      XCTAssertFalse(self->_callbackCalled, @"callback already called");
-      self->_callbackCalled = YES;
+      XCTAssertFalse(self->_completionCalled, @"callback already called");
+      self->_completionCalled = YES;
       self->_authError = error;
     };
     if (addScopesFlow) {
@@ -1236,7 +1236,7 @@ static void *kTestObserverContext = &kTestObserverContext;
 #elif TARGET_OS_OSX
         presentingWindow:_presentingWindow
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
-                callback:callback];
+              completion:completion];
     } else {
       if (useAdditionalScopes) {
         [_signIn signInWithConfiguration:_configuration
@@ -1247,7 +1247,7 @@ static void *kTestObserverContext = &kTestObserverContext;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                     hint:_hint
                         additionalScopes:additionalScopes
-                                callback:callback];
+                              completion:completion];
       } else {
         [_signIn signInWithConfiguration:_configuration
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
@@ -1256,7 +1256,7 @@ static void *kTestObserverContext = &kTestObserverContext;
                         presentingWindow:_presentingWindow
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                     hint:_hint
-                                callback:callback];
+                              completion:completion];
       }
     }
 
@@ -1305,8 +1305,8 @@ static void *kTestObserverContext = &kTestObserverContext;
 
   if (restoredSignIn && oldAccessToken) {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Callback should be called"];
-    [_signIn restorePreviousSignInWithCallback:^(GIDGoogleUser * _Nullable user,
-                                                 NSError * _Nullable error) {
+    [_signIn restorePreviousSignInWithCompletion:^(GIDGoogleUser * _Nullable user,
+                                                   NSError * _Nullable error) {
       [expectation fulfill];
       XCTAssertNil(error, @"should have no error");
     }];
@@ -1351,8 +1351,8 @@ static void *kTestObserverContext = &kTestObserverContext;
 
   if (restoredSignIn && !oldAccessToken) {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Callback should be called"];
-    [_signIn restorePreviousSignInWithCallback:^(GIDGoogleUser * _Nullable user,
-                                                 NSError * _Nullable error) {
+    [_signIn restorePreviousSignInWithCompletion:^(GIDGoogleUser * _Nullable user,
+                                                   NSError * _Nullable error) {
       [expectation fulfill];
       XCTAssertNil(error, @"should have no error");
     }];
@@ -1375,7 +1375,7 @@ static void *kTestObserverContext = &kTestObserverContext;
   XCTAssertTrue(profileData.hasImage);
 
   // If attempt to authenticate again, will reuse existing auth object.
-  _callbackCalled = NO;
+  _completionCalled = NO;
   _keychainRemoved = NO;
   _keychainSaved = NO;
   _authError = nil;
@@ -1385,18 +1385,18 @@ static void *kTestObserverContext = &kTestObserverContext;
     [[[_user expect] andReturn:_authentication] authentication];
   }
 
-  __block GIDAuthenticationAction action;
-  [[_authentication expect] doWithFreshTokens:SAVE_TO_ARG_BLOCK(action)];
+  __block GIDAuthenticationCompletion completion;
+  [[_authentication expect] doWithFreshTokens:SAVE_TO_ARG_BLOCK(completion)];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Callback should be called"];
 
-  [_signIn restorePreviousSignInWithCallback:^(GIDGoogleUser * _Nullable user,
-                                               NSError * _Nullable error) {
+  [_signIn restorePreviousSignInWithCompletion:^(GIDGoogleUser * _Nullable user,
+                                                 NSError * _Nullable error) {
     [expectation fulfill];
     XCTAssertNil(error, @"should have no error");
   }];
 
-  action(_authentication, nil);
+  completion(_authentication, nil);
 
   [self waitForExpectationsWithTimeout:1 handler:nil];
   XCTAssertFalse(_keychainRemoved, @"should not remove keychain");


### PR DESCRIPTION
Fixes #91 