### PR TITLE
Update macos runners to explicitly use 11 and 12

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-10.15]
+        os: [macos-11, macos-12]
   
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-10.15]
+        os: [macos-11, macos-12]
         podspec: [GoogleSignIn.podspec, GoogleSignInSwiftSupport.podspec]
         flag: [
           "", 
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-10.15]
+        os: [macos-11, macos-12]
         sdk: ['macosx', 'iphonesimulator']
         include:
           - sdk: 'macosx'


### PR DESCRIPTION
macos-10.15 is deprecated, and will be fully unsupported on [August 30](https://github.com/actions/virtual-environments/issues/5583).