### PR TITLE
Add keychain sharing entitlement to sign with dev certificate on macOS

### DIFF
--- a/Samples/Swift/DaysUntilBirthday/macOS/DaysUntilBirthdayOnMac.entitlements
+++ b/Samples/Swift/DaysUntilBirthday/macOS/DaysUntilBirthdayOnMac.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #192

Related to discussion in #191.