### PR TITLE
Fix Objc Sample App Build failure

### DIFF
--- a/Samples/ObjC/SignInSample/Source/AppDelegate.m
+++ b/Samples/ObjC/SignInSample/Source/AppDelegate.m
@@ -30,8 +30,8 @@
   // succeeds, we'll have a currentUser and the view will be able to draw its UI for the signed-in
   // state.  If the restore fails, currentUser will be nil and we'll draw the signed-out state
   // prompting the user to sign in.
-  [GIDSignIn.sharedInstance restorePreviousSignInWithCallback:^(GIDGoogleUser * _Nullable user,
-                                                                NSError * _Nullable error) {
+  [GIDSignIn.sharedInstance restorePreviousSignInWithCompletion:^(GIDGoogleUser *user,
+                                                                  NSError *error) {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     SignInViewController *masterViewController =
         [[SignInViewController alloc] initWithNibName:@"SignInViewController" bundle:nil];

--- a/Samples/ObjC/SignInSample/Source/SignInViewController.m
+++ b/Samples/ObjC/SignInSample/Source/SignInViewController.m
@@ -259,8 +259,7 @@ static NSString * const kClientID =
 - (IBAction)signIn:(id)sender {
   [GIDSignIn.sharedInstance signInWithConfiguration:_configuration
                            presentingViewController:self
-                                           callback:^(GIDGoogleUser * _Nullable user,
-                                                      NSError * _Nullable error) {
+                                         completion:^(GIDGoogleUser *user, NSError *error) {
     if (error) {
       self->_signInAuthStatus.text =
           [NSString stringWithFormat:@"Status: Authentication error: %@", error];
@@ -278,7 +277,7 @@ static NSString * const kClientID =
 }
 
 - (IBAction)disconnect:(id)sender {
-  [GIDSignIn.sharedInstance disconnectWithCallback:^(NSError * _Nullable error) {
+  [GIDSignIn.sharedInstance disconnectWithCompletion:^(NSError *error) {
     if (error) {
       self->_signInAuthStatus.text = [NSString stringWithFormat:@"Status: Failed to disconnect: %@",
                                       error];
@@ -293,8 +292,7 @@ static NSString * const kClientID =
 - (IBAction)addScopes:(id)sender {
   [GIDSignIn.sharedInstance addScopes:@[ @"https://www.googleapis.com/auth/user.birthday.read" ]
              presentingViewController:self
-                             callback:^(GIDGoogleUser * _Nullable user,
-                                        NSError * _Nullable error) {
+                           completion:^(GIDGoogleUser *user, NSError *error) {
     if (error) {
       self->_signInAuthStatus.text = [NSString stringWithFormat:@"Status: Failed to add scopes: %@",
                                       error];


### PR DESCRIPTION
Use the `completion` to replace `callback` according to the latest API change.