### PR TITLE
Fix resource loading in GoogleSignInSwift with CocoaPods use_frameworks!

### DIFF
--- a/GoogleSignInSwift/Sources/GoogleSignInButtonBundleExtensions.swift
+++ b/GoogleSignInSwift/Sources/GoogleSignInButtonBundleExtensions.swift
@@ -17,6 +17,7 @@
 #if !arch(arm) && !arch(i386)
 
 import Foundation
+import GoogleSignIn
 
 // MARK: - Bundle Extensions
 
@@ -40,7 +41,7 @@ extension Bundle {
       return Bundle(path: mainPath)
     }
 
-    let classBundle = Bundle(for: GoogleSignInButtonViewModel.self)
+    let classBundle = Bundle(for: GIDSignIn.self)
 
     if let classPath = classBundle.path(
       forResource: GoogleSignInBundleName,

--- a/GoogleSignInSwift/Tests/Unit/GoogleSignInButtonExtensionsTests.swift
+++ b/GoogleSignInSwift/Tests/Unit/GoogleSignInButtonExtensionsTests.swift
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import SwiftUI
+@testable import GoogleSignInSwift
+
+@available(iOS 13.0, macOS 10.15, *)
+class GoogleSignInButtonExtensionsTests: XCTestCase {
+
+  func testThatBundleExtensionReturnsImageIconURL() {
+    let googleIcon = Bundle.urlForGoogleResource(name: googleImageName, withExtension: "png")
+    XCTAssertNotNil(googleIcon)
+  }
+
+  func testThatBundleExtensionReturnsFontURL() {
+    let googleFont = Bundle.urlForGoogleResource(name: fontNameRobotoBold, withExtension: "ttf")
+    XCTAssertNotNil(googleFont)
+  }
+
+}


### PR DESCRIPTION
If a project using CocoaPods as its dependency manager added `use_frameworks!` in its `Podfile`, then we would fail to load resources from the bundle. This failure would lead to Google Sign-In image icon for the button to not load, for example. 

The reason for this failure was that we were previously using a class in the GoogleSignInSwift target to find the `Bundle`. While we would be able to find this `Bundle`, it would not contain the resources included in the `Bundle` for GoogleSignIn.

Fixes #194 