### PR TITLE
Temporarily revert breaking API changes for 6.2.3 patch release

### DIFF
--- a/GoogleSignIn/Sources/GIDAuthentication.m
+++ b/GoogleSignIn/Sources/GIDAuthentication.m
@@ -219,17 +219,17 @@ static NSString *const kNewIOSSystemName = @"iOS";
   return authorization;
 }
 
-- (void)doWithFreshTokens:(GIDAuthenticationCompletion)completion {
+- (void)doWithFreshTokens:(GIDAuthenticationAction)action {
   if (!([self.accessTokenExpirationDate timeIntervalSinceNow] < kMinimalTimeToExpire ||
       (self.idToken && [self.idTokenExpirationDate timeIntervalSinceNow] < kMinimalTimeToExpire))) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      completion(self, nil);
+      action(self, nil);
     });
     return;
   }
   @synchronized (_authenticationHandlerQueue) {
     // Push the handler into the callback queue.
-    [_authenticationHandlerQueue addObject:[completion copy]];
+    [_authenticationHandlerQueue addObject:[action copy]];
     if (_authenticationHandlerQueue.count > 1) {
       // This is not the first handler in the queue, no fetch is needed.
       return;
@@ -277,9 +277,9 @@ static NSString *const kNewIOSSystemName = @"iOS";
         authenticationHandlerQueue = [self->_authenticationHandlerQueue copy];
         [self->_authenticationHandlerQueue removeAllObjects];
       }
-      for (GIDAuthenticationCompletion completion in authenticationHandlerQueue) {
+      for (GIDAuthenticationAction action in authenticationHandlerQueue) {
         dispatch_async(dispatch_get_main_queue(), ^{
-          completion(error ? nil : self, error);
+          action(error ? nil : self, error);
         });
       }
     }];
@@ -289,9 +289,9 @@ static NSString *const kNewIOSSystemName = @"iOS";
       authenticationHandlerQueue = [self->_authenticationHandlerQueue copy];
       [self->_authenticationHandlerQueue removeAllObjects];
     }
-    for (GIDAuthenticationCompletion completion in authenticationHandlerQueue) {
+    for (GIDAuthenticationAction action in authenticationHandlerQueue) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        completion(error ? nil : self, error);
+        action(error ? nil : self, error);
       });
     }
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -187,8 +187,8 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   return [authState isAuthorized];
 }
 
-- (void)restorePreviousSignInWithCompletion:(nullable GIDSignInCompletion)completion {
-  [self signInWithOptions:[GIDSignInInternalOptions silentOptionsWithCompletion:completion]];
+- (void)restorePreviousSignInWithCallback:(nullable GIDSignInCallback)callback {
+  [self signInWithOptions:[GIDSignInInternalOptions silentOptionsWithCallback:callback]];
 }
 
 - (BOOL)restorePreviousSignInNoRefresh {
@@ -217,13 +217,13 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
-                     completion:(nullable GIDSignInCompletion)completion {
+                       callback:(nullable GIDSignInCallback)callback {
   GIDSignInInternalOptions *options =
       [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
                                        presentingViewController:presentingViewController
                                                       loginHint:hint
-                                                  addScopesFlow:NO
-                                                     completion:completion];
+                                                   addScopesFlow:NO
+                                                       callback:callback];
   [self signInWithOptions:options];
 }
 
@@ -231,38 +231,38 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
                additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                     completion:(nullable GIDSignInCompletion)completion {
+                       callback:(nullable GIDSignInCallback)callback {
   GIDSignInInternalOptions *options =
     [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
                                      presentingViewController:presentingViewController
                                                     loginHint:hint
                                                 addScopesFlow:NO
                                                        scopes:additionalScopes
-                                                   completion:completion];
+                                                     callback:callback];
   [self signInWithOptions:options];
 }
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
-                     completion:(nullable GIDSignInCompletion)completion {
+                       callback:(nullable GIDSignInCallback)callback {
   [self signInWithConfiguration:configuration
        presentingViewController:presentingViewController
                            hint:nil
-                     completion:completion];
+                       callback:callback];
 }
 
 - (void)addScopes:(NSArray<NSString *> *)scopes
     presentingViewController:(UIViewController *)presentingViewController
-                  completion:(nullable GIDSignInCompletion)completion {
+                    callback:(nullable GIDSignInCallback)callback {
   // A currentUser must be available in order to complete this flow.
   if (!self.currentUser) {
     // No currentUser is set, notify callback of failure.
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeNoCurrentUser
                                      userInfo:nil];
-    if (completion) {
+    if (callback) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        completion(nil, error);
+        callback(nil, error);
       });
     }
     return;
@@ -278,7 +278,7 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
                                        presentingViewController:presentingViewController
                                                       loginHint:self.currentUser.profile.email
                                                   addScopesFlow:YES
-                                                     completion:completion];
+                                                       callback:callback];
 
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
@@ -290,9 +290,9 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeScopesAlreadyGranted
                                      userInfo:nil];
-    if (completion) {
+    if (callback) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        completion(nil, error);
+        callback(nil, error);
       });
     }
     return;
@@ -310,52 +310,52 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
                            hint:(nullable NSString *)hint
-                     completion:(nullable GIDSignInCompletion)completion {
+                       callback:(nullable GIDSignInCallback)callback {
   GIDSignInInternalOptions *options =
       [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
                                                presentingWindow:presentingWindow
                                                       loginHint:hint
-                                                  addScopesFlow:NO
-                                                     completion:completion];
+                                                   addScopesFlow:NO
+                                                       callback:callback];
   [self signInWithOptions:options];
 }
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
-                     completion:(nullable GIDSignInCompletion)completion {
+                       callback:(nullable GIDSignInCallback)callback {
   [self signInWithConfiguration:configuration
                presentingWindow:presentingWindow
                            hint:nil
-                     completion:completion];
+                       callback:callback];
 }
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
                            hint:(nullable NSString *)hint
                additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                     completion:(nullable GIDSignInCompletion)completion {
+                       callback:(nullable GIDSignInCallback)callback {
   GIDSignInInternalOptions *options =
     [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
                                              presentingWindow:presentingWindow
                                                     loginHint:hint
                                                 addScopesFlow:NO
                                                        scopes:additionalScopes
-                                                   completion:completion];
+                                                     callback:callback];
   [self signInWithOptions:options];
 }
 
 - (void)addScopes:(NSArray<NSString *> *)scopes
- presentingWindow:(NSWindow *)presentingWindow
-       completion:(nullable GIDSignInCompletion)completion {
+            presentingWindow:(NSWindow *)presentingWindow
+                    callback:(nullable GIDSignInCallback)callback {
   // A currentUser must be available in order to complete this flow.
   if (!self.currentUser) {
     // No currentUser is set, notify callback of failure.
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeNoCurrentUser
                                      userInfo:nil];
-    if (completion) {
+    if (callback) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        completion(nil, error);
+        callback(nil, error);
       });
     }
     return;
@@ -371,7 +371,7 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
                                                presentingWindow:presentingWindow
                                                       loginHint:self.currentUser.profile.email
                                                   addScopesFlow:YES
-                                                     completion:completion];
+                                                       callback:callback];
 
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
@@ -383,9 +383,9 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeScopesAlreadyGranted
                                      userInfo:nil];
-    if (completion) {
+    if (callback) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        completion(nil, error);
+        callback(nil, error);
       });
     }
     return;
@@ -411,7 +411,7 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   [self removeAllKeychainEntries];
 }
 
-- (void)disconnectWithCompletion:(nullable GIDDisconnectCompletion)completion {
+- (void)disconnectWithCallback:(nullable GIDDisconnectCallback)callback {
   GIDGoogleUser *user = _currentUser;
   OIDAuthState *authState = user.authentication.authState;
   if (!authState) {
@@ -428,9 +428,9 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   if (!token) {
     [self signOut];
     // Nothing to do here, consider the operation successful.
-    if (completion) {
+    if (callback) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        completion(nil);
+        callback(nil);
       });
     }
     return;
@@ -453,9 +453,9 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
     if (!error) {
       [self signOut];
     }
-    if (completion) {
+    if (callback) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        completion(error);
+        callback(error);
       });
     }
   }];
@@ -538,10 +538,10 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
       if (error) {
         [self authenticateWithOptions:options];
       } else {
-        if (options.completion) {
+        if (options.callback) {
           self->_currentOptions = nil;
           dispatch_async(dispatch_get_main_queue(), ^{
-            options.completion(self->_currentUser, nil);
+            options.callback(self->_currentUser, nil);
           });
         }
       }
@@ -707,10 +707,10 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
     NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
                                          code:kGIDSignInErrorCodeHasNoAuthInKeychain
                                      userInfo:nil];
-    if (options.completion) {
+    if (options.callback) {
       _currentOptions = nil;
       dispatch_async(dispatch_get_main_queue(), ^{
-        options.completion(nil, error);
+        options.callback(nil, error);
       });
     }
     return;
@@ -881,11 +881,11 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
   __weak GIDAuthFlow *weakAuthFlow = authFlow;
   [authFlow addCallback:^() {
     GIDAuthFlow *handlerAuthFlow = weakAuthFlow;
-    if (self->_currentOptions.completion) {
-      GIDSignInCompletion completion = self->_currentOptions.completion;
+    if (self->_currentOptions.callback) {
+      GIDSignInCallback callback = self->_currentOptions.callback;
       self->_currentOptions = nil;
       dispatch_async(dispatch_get_main_queue(), ^{
-        completion(self->_currentUser, handlerAuthFlow.error);
+        callback(self->_currentUser, handlerAuthFlow.error);
       });
     }
   }];

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.h
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.h
@@ -54,8 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly, weak, nullable) NSWindow *presentingWindow;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 
-/// The completion block to be called at the completion of the flow.
-@property(nonatomic, readonly, nullable) GIDSignInCompletion completion;
+/// The callback block to be called at the completion of the flow.
+@property(nonatomic, readonly, nullable) GIDSignInCallback callback;
 
 /// The scopes to be used during the flow.
 @property(nonatomic, copy, nullable) NSArray<NSString *> *scopes;
@@ -69,32 +69,32 @@ NS_ASSUME_NONNULL_BEGIN
                        presentingViewController:(nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
-                                     completion:(nullable GIDSignInCompletion)completion;
+                                       callback:(nullable GIDSignInCallback)callback;
 
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                        presentingViewController:(nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
-                                     completion:(nullable GIDSignInCompletion)completion;
+                                       callback:(nullable GIDSignInCallback)callback;
 
 #elif TARGET_OS_OSX
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                                presentingWindow:(nullable NSWindow *)presentingWindow
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
-                                     completion:(nullable GIDSignInCompletion)completion;
+                                       callback:(nullable GIDSignInCallback)callback;
 
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                                presentingWindow:(nullable NSWindow *)presentingWindow
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
-                                     completion:(nullable GIDSignInCompletion)completion;
+                                       callback:(nullable GIDSignInCallback)callback;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 
 /// Creates the options to sign in silently.
-+ (instancetype)silentOptionsWithCompletion:(GIDSignInCompletion)completion;
++ (instancetype)silentOptionsWithCallback:(GIDSignInCallback)callback;
 
 /// Creates options with the same values as the receiver, except for the "extra parameters", and
 /// continuation flag, which are replaced by the arguments passed to this method.

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.m
@@ -31,14 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
-                                     completion:(nullable GIDSignInCompletion)completion {
+                                       callback:(nullable GIDSignInCallback)callback {
 #elif TARGET_OS_OSX
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                                presentingWindow:(nullable NSWindow *)presentingWindow
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
-                                     completion:(nullable GIDSignInCompletion)completion {
+                                       callback:(nullable GIDSignInCallback)callback {
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
   
   GIDSignInInternalOptions *options = [[GIDSignInInternalOptions alloc] init];
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_presentingWindow = presentingWindow;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
     options->_loginHint = loginHint;
-    options->_completion = completion;
+    options->_callback = callback;
     options->_scopes = [GIDScopes scopesWithBasicProfile:scopes];
   }
   return options;
@@ -64,13 +64,13 @@ NS_ASSUME_NONNULL_BEGIN
                        presentingViewController:(nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
-                                     completion:(nullable GIDSignInCompletion)completion {
+                                       callback:(nullable GIDSignInCallback)callback {
 #elif TARGET_OS_OSX
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
                                presentingWindow:(nullable NSWindow *)presentingWindow
                                       loginHint:(nullable NSString *)loginHint
                                   addScopesFlow:(BOOL)addScopesFlow
-                                     completion:(nullable GIDSignInCompletion)completion {
+                                       callback:(nullable GIDSignInCallback)callback {
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
     GIDSignInInternalOptions *options = [self defaultOptionsWithConfiguration:configuration
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
@@ -81,11 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
                                                                     loginHint:loginHint
                                                                 addScopesFlow:addScopesFlow
                                                                        scopes:@[]
-                                                                   completion:completion];
+                                                                     callback:callback];
   return options;
 }
 
-+ (instancetype)silentOptionsWithCompletion:(GIDSignInCompletion)completion {
++ (instancetype)silentOptionsWithCallback:(GIDSignInCallback)callback {
   GIDSignInInternalOptions *options = [self defaultOptionsWithConfiguration:nil
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                                    presentingViewController:nil
@@ -93,8 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                            presentingWindow:nil
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                                                   loginHint:nil
-                                                              addScopesFlow:NO
-                                                                 completion:completion];
+                                                               addScopesFlow:NO
+                                                                   callback:callback];
   if (options) {
     options->_interactive = NO;
   }
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_presentingWindow = _presentingWindow;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
     options->_loginHint = _loginHint;
-    options->_completion = _completion;
+    options->_callback = _callback;
     options->_scopes = _scopes;
     options->_extraParams = [extraParams copy];
   }

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h
@@ -28,10 +28,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// A completion block that takes a `GIDAuthentication` or an error if the attempt to refresh tokens
+/// A callback block that takes a `GIDAuthentication` or an error if the attempt to refresh tokens
 /// was unsuccessful.
-typedef void (^GIDAuthenticationCompletion)(GIDAuthentication *_Nullable authentication,
-                                            NSError *_Nullable error);
+typedef void (^GIDAuthenticationAction)(GIDAuthentication *_Nullable authentication,
+                                        NSError *_Nullable error);
 
 /// This class represents the OAuth 2.0 entities needed for sign-in.
 @interface GIDAuthentication : NSObject <NSSecureCoding>
@@ -64,10 +64,9 @@ typedef void (^GIDAuthenticationCompletion)(GIDAuthentication *_Nullable authent
 /// Get a valid access token and a valid ID token, refreshing them first if they have expired or are
 /// about to expire.
 ///
-/// @param completion A completion block that takes a `GIDAuthentication` or an error if the attempt
-///     to refresh tokens was unsuccessful.  The block will be called asynchronously on the main
-///     queue.
-- (void)doWithFreshTokens:(GIDAuthenticationCompletion)completion;
+/// @param action A callback block that takes a `GIDAuthentication` or an error if the attempt to
+///     refresh tokens was unsuccessful.  The block will be called asynchronously on the main queue.
+- (void)doWithFreshTokens:(GIDAuthenticationAction)action;
 
 @end
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -50,12 +50,12 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
   kGIDSignInErrorCodeScopesAlreadyGranted = -8,
 };
 
-/// Represents a completion block that takes a `GIDGoogleUser` on success or an error if the operation
+/// Represents a callback block that takes a `GIDGoogleUser` on success or an error if the operation
 /// was unsuccessful.
-typedef void (^GIDSignInCompletion)(GIDGoogleUser *_Nullable user, NSError *_Nullable error);
+typedef void (^GIDSignInCallback)(GIDGoogleUser *_Nullable user, NSError *_Nullable error);
 
-/// Represents a completion block that takes an error if the operation was unsuccessful.
-typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
+/// Represents a callback block that takes an error if the operation was unsuccessful.
+typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
 
 /// This class signs the user in with Google.
 ///
@@ -91,9 +91,9 @@ typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
 
 /// Attempts to restore a previously authenticated user without interaction.
 ///
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
-- (void)restorePreviousSignInWithCompletion:(nullable GIDSignInCompletion)completion;
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
+- (void)restorePreviousSignInWithCallback:(nullable GIDSignInCallback)callback;
 
 /// Marks current user as being in the signed out state.
 - (void)signOut;
@@ -101,35 +101,35 @@ typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
 /// Disconnects the current user from the app and revokes previous authentication. If the operation
 /// succeeds, the OAuth 2.0 token is also removed from keychain.
 ///
-/// @param completion The optional `GIDDisconnectCompletion` block that is called on completion.
-///     This block will be called asynchronously on the main queue.
-- (void)disconnectWithCompletion:(nullable GIDDisconnectCompletion)completion;
+/// @param callback The optional `GIDDisconnectCallback` block that is called on completion.  This
+///     block will be called asynchronously on the main queue.
+- (void)disconnectWithCallback:(nullable GIDDisconnectCallback)callback;
 
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 /// Starts an interactive sign-in flow on iOS using the provided configuration.
 ///
-/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// The callback will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
 ///     iOS 9 and 10 and to supply `presentationContextProvider` for `ASWebAuthenticationSession` on
 ///     iOS 13+.
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
-                     completion:(nullable GIDSignInCompletion)completion
+                       callback:(nullable GIDSignInCallback)callback
     NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
-/// Starts an interactive sign-in flow on iOS using the provided configuration and a login hint.
+/// Starts an interactive sign-in flow  on iOS using the provided configuration and a login hint.
 ///
-/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// The callback will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
@@ -137,20 +137,20 @@ typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
 ///     iOS 13+.
 /// @param hint An optional hint for the authorization server, for example the user's ID or email
 ///     address, to be prefilled if possible.
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
-                     completion:(nullable GIDSignInCompletion)completion
+                       callback:(nullable GIDSignInCallback)callback
     NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
 /// Starts an interactive sign-in flow on iOS using the provided configuration and a login hint.
 ///
-/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// The callback will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
@@ -158,98 +158,98 @@ typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
 /// @param hint An optional hint for the authorization server, for example the user's ID or email
 ///     address, to be prefilled if possible.
 /// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
                            hint:(nullable NSString *)hint
                additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                     completion:(nullable GIDSignInCompletion)completion;
+                       callback:(nullable GIDSignInCallback)callback;
 
 /// Starts an interactive consent flow on iOS to add scopes to the current user's grants.
 ///
-/// The completion will be called at the end of this process.  If successful, a new `GIDGoogleUser`
+/// The callback will be called at the end of this process.  If successful, a new `GIDGoogleUser`
 /// instance will be returned reflecting the new scopes and saved sign-in state will be updated.
 ///
 /// @param scopes The scopes to ask the user to consent to.
 /// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
 ///     iOS 9 and 10 and to supply `presentationContextProvider` for `ASWebAuthenticationSession` on
 ///     iOS 13+.
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
 - (void)addScopes:(NSArray<NSString *> *)scopes
     presentingViewController:(UIViewController *)presentingViewController
-                  completion:(nullable GIDSignInCompletion)completion
+                    callback:(nullable GIDSignInCallback)callback
     NS_EXTENSION_UNAVAILABLE("The add scopes flow is not supported in App Extensions."); 
 
 #elif TARGET_OS_OSX
 /// Starts an interactive sign-in flow on macOS using the provided configuration.
 ///
-/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// The callback will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
-                     completion:(nullable GIDSignInCompletion)completion;
+                       callback:(nullable GIDSignInCallback)callback;
 
 /// Starts an interactive sign-in flow on macOS using the provided configuration and a login hint.
 ///
-/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// The callback will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
 /// @param hint An optional hint for the authorization server, for example the user's ID or email
 ///     address, to be prefilled if possible.
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
                            hint:(nullable NSString *)hint
-                     completion:(nullable GIDSignInCompletion)completion;
+                       callback:(nullable GIDSignInCallback)callback;
 
 /// Starts an interactive sign-in flow on macOS using the provided configuration and a login hint.
 ///
-/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// The callback will be called at the end of this process.  Any saved sign-in state will be
 /// replaced by the result of this flow.  Note that this method should not be called when the app is
 /// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
-/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
 ///
 /// @param configuration The configuration properties to be used for this flow.
 /// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
 /// @param hint An optional hint for the authorization server, for example the user's ID or email
 ///     address, to be prefilled if possible.
 /// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
                presentingWindow:(NSWindow *)presentingWindow
                            hint:(nullable NSString *)hint
                additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                     completion:(nullable GIDSignInCompletion)completion;
+                       callback:(nullable GIDSignInCallback)callback;
 
 /// Starts an interactive consent flow on macOS to add scopes to the current user's grants.
 ///
-/// The completion will be called at the end of this process.  If successful, a new `GIDGoogleUser`
+/// The callback will be called at the end of this process.  If successful, a new `GIDGoogleUser`
 /// instance will be returned reflecting the new scopes and saved sign-in state will be updated.
 ///
 /// @param scopes An array of scopes to ask the user to consent to.
 /// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
-/// @param completion The `GIDSignInCompletion` block that is called on completion.  This block will
-///     be called asynchronously on the main queue.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
 - (void)addScopes:(NSArray<NSString *> *)scopes
- presentingWindow:(NSWindow *)presentingWindow
-       completion:(nullable GIDSignInCompletion)completion;
+       presentingWindow:(NSWindow *)presentingWindow
+               callback:(nullable GIDSignInCallback)callback;
 
 #endif
 

--- a/GoogleSignIn/Tests/Unit/GIDSignInInternalOptionsTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInInternalOptionsTest.m
@@ -37,7 +37,7 @@
   id presentingWindow = OCMStrictClassMock([NSWindow class]);
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
   NSString *loginHint = @"login_hint";
-  GIDSignInCompletion completion = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {};
+  GIDSignInCallback callback = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {};
   
   GIDSignInInternalOptions *options =
       [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
@@ -47,8 +47,8 @@
                                                presentingWindow:presentingWindow
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
                                                       loginHint:loginHint
-                                                  addScopesFlow:NO
-                                                     completion:completion];
+                                                   addScopesFlow:NO
+                                                       callback:callback];
   XCTAssertTrue(options.interactive);
   XCTAssertFalse(options.continuation);
   XCTAssertFalse(options.addScopesFlow);
@@ -63,13 +63,12 @@
 }
 
 - (void)testSilentOptions {
-  GIDSignInCompletion completion = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {};
-  GIDSignInInternalOptions *options = [GIDSignInInternalOptions
-                                       silentOptionsWithCompletion:completion];
+  GIDSignInCallback callback = ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {};
+  GIDSignInInternalOptions *options = [GIDSignInInternalOptions silentOptionsWithCallback:callback];
   XCTAssertFalse(options.interactive);
   XCTAssertFalse(options.continuation);
   XCTAssertNil(options.extraParams);
-  XCTAssertEqual(options.completion, completion);
+  XCTAssertEqual(options.callback, callback);
 }
 
 @end

--- a/Samples/ObjC/SignInSample/Source/AppDelegate.m
+++ b/Samples/ObjC/SignInSample/Source/AppDelegate.m
@@ -30,8 +30,8 @@
   // succeeds, we'll have a currentUser and the view will be able to draw its UI for the signed-in
   // state.  If the restore fails, currentUser will be nil and we'll draw the signed-out state
   // prompting the user to sign in.
-  [GIDSignIn.sharedInstance restorePreviousSignInWithCompletion:^(GIDGoogleUser *user,
-                                                                  NSError *error) {
+  [GIDSignIn.sharedInstance restorePreviousSignInWithCallback:^(GIDGoogleUser * _Nullable user,
+                                                                NSError * _Nullable error) {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     SignInViewController *masterViewController =
         [[SignInViewController alloc] initWithNibName:@"SignInViewController" bundle:nil];

--- a/Samples/ObjC/SignInSample/Source/SignInViewController.m
+++ b/Samples/ObjC/SignInSample/Source/SignInViewController.m
@@ -259,7 +259,8 @@ static NSString * const kClientID =
 - (IBAction)signIn:(id)sender {
   [GIDSignIn.sharedInstance signInWithConfiguration:_configuration
                            presentingViewController:self
-                                         completion:^(GIDGoogleUser *user, NSError *error) {
+                                           callback:^(GIDGoogleUser * _Nullable user,
+                                                      NSError * _Nullable error) {
     if (error) {
       self->_signInAuthStatus.text =
           [NSString stringWithFormat:@"Status: Authentication error: %@", error];
@@ -277,7 +278,7 @@ static NSString * const kClientID =
 }
 
 - (IBAction)disconnect:(id)sender {
-  [GIDSignIn.sharedInstance disconnectWithCompletion:^(NSError *error) {
+  [GIDSignIn.sharedInstance disconnectWithCallback:^(NSError * _Nullable error) {
     if (error) {
       self->_signInAuthStatus.text = [NSString stringWithFormat:@"Status: Failed to disconnect: %@",
                                       error];
@@ -292,7 +293,8 @@ static NSString * const kClientID =
 - (IBAction)addScopes:(id)sender {
   [GIDSignIn.sharedInstance addScopes:@[ @"https://www.googleapis.com/auth/user.birthday.read" ]
              presentingViewController:self
-                           completion:^(GIDGoogleUser *user, NSError *error) {
+                             callback:^(GIDGoogleUser * _Nullable user,
+                                        NSError * _Nullable error) {
     if (error) {
       self->_signInAuthStatus.text = [NSString stringWithFormat:@"Status: Failed to add scopes: %@",
                                       error];


### PR DESCRIPTION
For SemVer compliance, we do not want to include the breaking callback -> completion renaming in our pending 6.2.3 release.