### PR TITLE
fix: Document comment for GIDSignInButtonStyle

### DIFF
--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignInButton.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignInButton.h
@@ -25,9 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// The minimum size of the button depends on the language used for text.
 /// The following dimensions (in points) fit for all languages:
-/// - kGIDSignInButtonStyleStandard: 230 x 48
-/// - kGIDSignInButtonStyleWide:     312 x 48
-/// - kGIDSignInButtonStyleIconOnly: 48 x 48 (no text, fixed size)
+/// - kGIDSignInButtonStyleStandard: 230 x 48 (Display text is "Sign in")
+/// - kGIDSignInButtonStyleWide:     312 x 48 (Display text is "Sign in with Google")
+/// - kGIDSignInButtonStyleIconOnly: 48 x 48  (no text, fixed size)
 typedef NS_ENUM(NSInteger, GIDSignInButtonStyle) {
   kGIDSignInButtonStyleStandard = 0,
   kGIDSignInButtonStyleWide = 1,


### PR DESCRIPTION
I worked on https://github.com/google/GoogleSignIn-iOS/issues/203

I think to be customizable the display text is better than adding document comments like this, so this is a workaround.