### PR TITLE
Add unit test for `updateAuthState:` in GIDGoogleUserTest

### DIFF
--- a/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
@@ -105,7 +105,7 @@ static NSTimeInterval const kTimeAccuracy = 10;
 }
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 
-- (void) testUpdateAuthState {
+- (void)testUpdateAuthState {
   NSString *idToken = [self idTokenWithExpireTime:kIDTokenExpireTime];
   OIDAuthState *authState = [OIDAuthState testInstanceWithIDToken:idToken
                                                       accessToken:kAccessToken

--- a/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
@@ -119,13 +119,15 @@ static NSTimeInterval const kTimeAccuracy = 10;
   XCTAssertEqualObjects(user.idToken.tokenString, idToken);
   XCTAssertEqualWithAccuracy([user.idToken.expirationDate timeIntervalSinceReferenceDate],
                              kIDTokenExpireTime, kTimeAccuracy);
+  XCTAssertNil(user.profile);
   
   NSString *idTokenNew = [self idTokenWithExpireTime:kNewIDTokenExpireTime];
   OIDAuthState *newAuthState = [OIDAuthState testInstanceWithIDToken:idTokenNew
                                                          accessToken:kNewAccessToken
                                                accessTokenExpireTime:kNewAccessTokenExpireTime];
+  GIDProfileData *newProfileData = [GIDProfileData testInstance];
   
-  [user updateAuthState:newAuthState profileData:nil];
+  [user updateAuthState:newAuthState profileData:newProfileData];
   
   XCTAssertEqualObjects(user.accessToken.tokenString, kNewAccessToken);
   XCTAssertEqualWithAccuracy([user.accessToken.expirationDate timeIntervalSinceReferenceDate],
@@ -133,6 +135,7 @@ static NSTimeInterval const kTimeAccuracy = 10;
   XCTAssertEqualObjects(user.idToken.tokenString, idTokenNew);
   XCTAssertEqualWithAccuracy([user.idToken.expirationDate timeIntervalSinceReferenceDate],
                              kNewIDTokenExpireTime, kTimeAccuracy);
+  XCTAssertEqual(user.profile, newProfileData);
 }
 
 #pragma mark - Helpers

--- a/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
@@ -37,6 +37,9 @@
 
 static NSString *const kNewAccessToken = @"new_access_token";
 static NSTimeInterval const kTimeAccuracy = 10;
+// The difference between times.
+// It should be larger than kTimeAccuracy which is used in the method `XCTAssertEqualWithAccuracy`.
+static NSTimeInterval const kTimeIncrement = 100;
 
 @interface GIDGoogleUserTest : XCTestCase
 @end
@@ -97,7 +100,7 @@ static NSTimeInterval const kTimeAccuracy = 10;
 
 - (void)testUpdateAuthState {
   NSTimeInterval accessTokenExpireTime = [NSDate timeIntervalSinceReferenceDate];
-  NSTimeInterval idTokenExpireTime = [NSDate timeIntervalSinceReferenceDate] + 100;
+  NSTimeInterval idTokenExpireTime = accessTokenExpireTime + kTimeIncrement;
   
   NSString *idToken = [self idTokenWithExpireTime:idTokenExpireTime];
   OIDAuthState *authState = [OIDAuthState testInstanceWithIDToken:idToken
@@ -106,16 +109,8 @@ static NSTimeInterval const kTimeAccuracy = 10;
   
   GIDGoogleUser *user = [[GIDGoogleUser alloc] initWithAuthState:authState profileData:nil];
   
-  XCTAssertEqualObjects(user.accessToken.tokenString, kAccessToken);
-  XCTAssertEqualWithAccuracy([user.accessToken.expirationDate timeIntervalSinceReferenceDate],
-                             accessTokenExpireTime, kTimeAccuracy);
-  XCTAssertEqualObjects(user.idToken.tokenString, idToken);
-  XCTAssertEqualWithAccuracy([user.idToken.expirationDate timeIntervalSinceReferenceDate],
-                             idTokenExpireTime, kTimeAccuracy);
-  XCTAssertNil(user.profile);
-  
-  NSTimeInterval updatedAccessTokenExpireTime = [NSDate timeIntervalSinceReferenceDate] + 200;
-  NSTimeInterval updatedIDTokenExpireTime = [NSDate timeIntervalSinceReferenceDate] + 300;
+  NSTimeInterval updatedAccessTokenExpireTime = idTokenExpireTime + kTimeIncrement;
+  NSTimeInterval updatedIDTokenExpireTime = updatedAccessTokenExpireTime + kTimeIncrement;
   NSString *updatedIDToken = [self idTokenWithExpireTime:updatedIDTokenExpireTime];
   OIDAuthState *updatedAuthState = [OIDAuthState testInstanceWithIDToken:updatedIDToken
                                                              accessToken:kNewAccessToken

--- a/GoogleSignIn/Tests/Unit/OIDAuthState+Testing.h
+++ b/GoogleSignIn/Tests/Unit/OIDAuthState+Testing.h
@@ -28,4 +28,8 @@
 
 + (instancetype)testInstanceWithTokenResponse:(OIDTokenResponse *)tokenResponse;
 
++ (instancetype)testInstanceWithIDToken:(NSString *)idToken
+                            accessToken:(NSString *)accessToken
+                  accessTokenExpireTime:(NSTimeInterval)accessTokenExpireTime;
+
 @end

--- a/GoogleSignIn/Tests/Unit/OIDAuthState+Testing.m
+++ b/GoogleSignIn/Tests/Unit/OIDAuthState+Testing.m
@@ -33,4 +33,17 @@
                                                tokenResponse:tokenResponse];
 }
 
++ (instancetype)testInstanceWithIDToken:(NSString *)idToken
+                            accessToken:(NSString *)accessToken
+                  accessTokenExpireTime:(NSTimeInterval)accessTokenExpireTime {
+  NSNumber *accessTokenExpiresIn =
+      @(accessTokenExpireTime - [[NSDate date] timeIntervalSinceReferenceDate]);
+  OIDTokenResponse *newResponse =
+    [OIDTokenResponse testInstanceWithIDToken:idToken
+                                  accessToken:accessToken
+                                    expiresIn:accessTokenExpiresIn
+                                 tokenRequest:nil];
+  return [OIDAuthState testInstanceWithTokenResponse:newResponse];
+}
+
 @end

--- a/GoogleSignIn/Tests/Unit/OIDAuthState+Testing.m
+++ b/GoogleSignIn/Tests/Unit/OIDAuthState+Testing.m
@@ -39,11 +39,11 @@
   NSNumber *accessTokenExpiresIn =
       @(accessTokenExpireTime - [[NSDate date] timeIntervalSinceReferenceDate]);
   OIDTokenResponse *newResponse =
-    [OIDTokenResponse testInstanceWithIDToken:idToken
-                                  accessToken:accessToken
-                                    expiresIn:accessTokenExpiresIn
-                                 tokenRequest:nil];
-  return [OIDAuthState testInstanceWithTokenResponse:newResponse];
+      [OIDTokenResponse testInstanceWithIDToken:idToken
+                                    accessToken:accessToken
+                                      expiresIn:accessTokenExpiresIn
+                                   tokenRequest:nil];
+  return [self testInstanceWithTokenResponse:newResponse];
 }
 
 @end


### PR DESCRIPTION
Our plan is to merge GIDAuthentication into GIDGoogleUser. This PR is to add more coverage to exiting GIDGoogleUser API and prepare for more changes in the coming PRs.