### PR TITLE
Ignore warnings from GTMFetcherAuthorizationProtocol deprecation

### DIFF
--- a/GoogleSignIn/Sources/GIDAuthentication.m
+++ b/GoogleSignIn/Sources/GIDAuthentication.m
@@ -133,9 +133,12 @@ static NSString *const kNewIOSSystemName = @"iOS";
   GTMAppAuthFetcherAuthorizationEMMChainedDelegate *chainedDelegate =
       [[GTMAppAuthFetcherAuthorizationEMMChainedDelegate alloc] initWithDelegate:delegate
                                                                         selector:sel];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [super authorizeRequest:request
                  delegate:chainedDelegate
         didFinishSelector:@selector(authentication:request:finishedWithError:)];
+#pragma clang diagnostic pop
 }
 
 - (void)authorizeRequest:(nullable NSMutableURLRequest *)request
@@ -206,7 +209,10 @@ static NSString *const kNewIOSSystemName = @"iOS";
 
 #pragma mark - Public methods
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (id<GTMFetcherAuthorizationProtocol>)fetcherAuthorizer {
+#pragma clang diagnostic pop
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   GTMAppAuthFetcherAuthorization *authorization = self.emmSupport ?
       [[GTMAppAuthFetcherAuthorizationWithEMMSupport alloc] initWithAuthState:_authState] :

--- a/GoogleSignIn/Sources/GIDAuthentication.m
+++ b/GoogleSignIn/Sources/GIDAuthentication.m
@@ -127,9 +127,12 @@ static NSString *const kNewIOSSystemName = @"iOS";
 
 @implementation GTMAppAuthFetcherAuthorizationWithEMMSupport
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)authorizeRequest:(nullable NSMutableURLRequest *)request
                 delegate:(id)delegate
        didFinishSelector:(SEL)sel {
+#pragma clang diagnostic pop
   GTMAppAuthFetcherAuthorizationEMMChainedDelegate *chainedDelegate =
       [[GTMAppAuthFetcherAuthorizationEMMChainedDelegate alloc] initWithDelegate:delegate
                                                                         selector:sel];

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAuthentication.h
@@ -59,7 +59,10 @@ typedef void (^GIDAuthenticationCompletion)(GIDAuthentication *_Nullable authent
 /// Gets a new authorizer for `GTLService`, `GTMSessionFetcher`, or `GTMHTTPFetcher`.
 ///
 /// @return A new authorizer
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (id<GTMFetcherAuthorizationProtocol>)fetcherAuthorizer;
+#pragma clang diagnostic pop
 
 /// Get a valid access token and a valid ID token, refreshing them first if they have expired or are
 /// about to expire.

--- a/GoogleSignIn/Tests/Unit/GIDAuthenticationTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDAuthenticationTest.m
@@ -245,7 +245,10 @@ _Static_assert(kChangeTypeEnd == (sizeof(kObservedProperties) / sizeof(*kObserve
   // internally, so let's just take the shortcut here by asserting we get a
   // GTMAppAuthFetcherAuthorization object.
   GIDAuthentication *auth = [self auth];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   id<GTMFetcherAuthorizationProtocol> fetcherAuthroizer = auth.fetcherAuthorizer;
+#pragma clang diagnostic pop
   XCTAssertTrue([fetcherAuthroizer isKindOfClass:[GTMAppAuthFetcherAuthorization class]]);
   XCTAssertTrue([fetcherAuthroizer canAuthorize]);
 }


### PR DESCRIPTION
With the release of [GTMAppAuth 1.3.1](https://github.com/google/GTMAppAuth/releases/tag/1.3.1), we're now building against GTMSessionFetcher 2.1.x by default and need to handle warnings stemming from the [deprecation of `GTMFetcherAuthorizationProtocol`](https://github.com/google/gtm-session-fetcher/pull/315).