### PR TITLE
Add CODE_SIGNING_ALLOWED in podspec (#223)

### DIFF
--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -42,7 +42,8 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
     'GCC_PREPROCESSOR_DEFINITIONS' => 'GID_SDK_VERSION=' + s.version.to_s,
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
     'DEFINES_MODULE' => 'YES',
-    'COMBINE_HIDPI_IMAGES' => 'NO'
+    'COMBINE_HIDPI_IMAGES' => 'NO',
+    'CODE_SIGNING_ALLOWED' => 'NO'
   }
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {


### PR DESCRIPTION
Tested locally but not on real cocoapod env yet.
Adding CODE_SIGNING_ALLOWED = No in Build Setting to avoid XCode 14 build issue since on XCode 14 the default of CODE_SIGNING_ALLOWED is YES.