### PR TITLE
Use NSTimeIntervalSince1970 to replace timeIntervalSinceReferenceDate

### DIFF
--- a/GoogleSignIn/Tests/Unit/GIDAuthenticationTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDAuthenticationTest.m
@@ -554,7 +554,7 @@ _Static_assert(kChangeTypeEnd == (sizeof(kObservedProperties) / sizeof(*kObserve
 - (GIDAuthentication *)auth {
   NSString *idToken = [self idToken];
   NSNumber *accessTokenExpiresIn =
-      @(_accessTokenExpireTime - [[NSDate date] timeIntervalSinceReferenceDate]);
+      @(_accessTokenExpireTime - [[NSDate date] timeIntervalSince1970]);
   OIDTokenRequest *tokenRequest =
       [OIDTokenRequest testInstanceWithAdditionalParameters:_additionalTokenRequestParameters];
   OIDTokenResponse *tokenResponse =
@@ -570,7 +570,7 @@ _Static_assert(kChangeTypeEnd == (sizeof(kObservedProperties) / sizeof(*kObserve
   if (!_hasIDToken) {
     return nil;
   }
-  return [OIDTokenResponse idTokenWithSub:kUserID exp:@(expireTime + NSTimeIntervalSince1970)];
+  return [OIDTokenResponse idTokenWithSub:kUserID exp:@(expireTime)];
 }
 
 - (NSString *)idToken {
@@ -595,7 +595,7 @@ _Static_assert(kChangeTypeEnd == (sizeof(kObservedProperties) / sizeof(*kObserve
 }
 
 - (OIDTokenResponse *)tokenResponseWithNewTokens {
-  NSNumber *expiresIn = @(kNewExpireTime - [NSDate timeIntervalSinceReferenceDate]);
+  NSNumber *expiresIn = @(kNewExpireTime - [[NSDate date] timeIntervalSince1970]);
   return [OIDTokenResponse testInstanceWithIDToken:(_hasIDToken ? [self idTokenNew] : nil)
                                        accessToken:kNewAccessToken
                                          expiresIn:expiresIn
@@ -607,7 +607,7 @@ _Static_assert(kChangeTypeEnd == (sizeof(kObservedProperties) / sizeof(*kObserve
 }
 
 - (void)assertDate:(NSDate *)date equalTime:(NSTimeInterval)time {
-  XCTAssertEqualWithAccuracy([date timeIntervalSinceReferenceDate], time, kTimeAccuracy);
+  XCTAssertEqualWithAccuracy([date timeIntervalSince1970], time, kTimeAccuracy);
 }
 
 - (void)assertOldAccessTokenInAuth:(GIDAuthentication *)auth {
@@ -643,8 +643,8 @@ _Static_assert(kChangeTypeEnd == (sizeof(kObservedProperties) / sizeof(*kObserve
 }
 
 - (void)setExpireTimeForAccessToken:(NSTimeInterval)accessExpire IDToken:(NSTimeInterval)idExpire {
-  _accessTokenExpireTime = [[NSDate date] timeIntervalSinceReferenceDate] + accessExpire;
-  _idTokenExpireTime = [[NSDate date] timeIntervalSinceReferenceDate] + idExpire;
+  _accessTokenExpireTime = [[NSDate date] timeIntervalSince1970] + accessExpire;
+  _idTokenExpireTime = [[NSDate date] timeIntervalSince1970] + idExpire;
 }
 
 - (void)verifyTokensRefreshedWithMethod:(SEL)sel {

--- a/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
@@ -99,7 +99,7 @@ static NSTimeInterval const kTimeIncrement = 100;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 
 - (void)testUpdateAuthState {
-  NSTimeInterval accessTokenExpireTime = [NSDate timeIntervalSinceReferenceDate];
+  NSTimeInterval accessTokenExpireTime = [[NSDate date] timeIntervalSince1970];
   NSTimeInterval idTokenExpireTime = accessTokenExpireTime + kTimeIncrement;
   
   NSString *idToken = [self idTokenWithExpireTime:idTokenExpireTime];
@@ -120,18 +120,19 @@ static NSTimeInterval const kTimeIncrement = 100;
   [user updateAuthState:updatedAuthState profileData:updatedProfileData];
   
   XCTAssertEqualObjects(user.accessToken.tokenString, kNewAccessToken);
-  XCTAssertEqualWithAccuracy([user.accessToken.expirationDate timeIntervalSinceReferenceDate],
+  XCTAssertEqualWithAccuracy([user.accessToken.expirationDate timeIntervalSince1970],
                              updatedAccessTokenExpireTime, kTimeAccuracy);
   XCTAssertEqualObjects(user.idToken.tokenString, updatedIDToken);
-  XCTAssertEqualWithAccuracy([user.idToken.expirationDate timeIntervalSinceReferenceDate],
+  XCTAssertEqualWithAccuracy([user.idToken.expirationDate timeIntervalSince1970],
                              updatedIDTokenExpireTime, kTimeAccuracy);
   XCTAssertEqual(user.profile, updatedProfileData);
 }
 
 #pragma mark - Helpers
 
+// The expireTime should be based on 1970.
 - (NSString *)idTokenWithExpireTime:(NSTimeInterval)expireTime {
-  return [OIDTokenResponse idTokenWithSub:kUserID exp:@(expireTime + NSTimeIntervalSince1970)];
+  return [OIDTokenResponse idTokenWithSub:kUserID exp:@(expireTime)];
 }
 
 @end

--- a/GoogleSignIn/Tests/Unit/OIDAuthState+Testing.m
+++ b/GoogleSignIn/Tests/Unit/OIDAuthState+Testing.m
@@ -37,7 +37,7 @@
                             accessToken:(NSString *)accessToken
                   accessTokenExpireTime:(NSTimeInterval)accessTokenExpireTime {
   NSNumber *accessTokenExpiresIn =
-      @(accessTokenExpireTime - [[NSDate date] timeIntervalSinceReferenceDate]);
+      @(accessTokenExpireTime - [[NSDate date] timeIntervalSince1970]);
   OIDTokenResponse *newResponse =
       [OIDTokenResponse testInstanceWithIDToken:idToken
                                     accessToken:accessToken

--- a/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h
+++ b/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h
@@ -63,8 +63,8 @@ extern NSString * const kFatPictureURL;
 + (NSString *)fatIDToken;
 
 /**
- * @sub The subject of the user.
- * @exp The interval between the expire date and 00:00:00 UTC on 1 January 1970.
+ * @sub The subject of the ID token.
+ * @exp The interval between 00:00:00 UTC on 1 January 1970 and the expiration date of the ID token.
  */
 + (NSString *)idTokenWithSub:(NSString *)sub exp:(NSNumber *)exp;
 

--- a/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h
+++ b/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h
@@ -62,6 +62,10 @@ extern NSString * const kFatPictureURL;
 
 + (NSString *)fatIDToken;
 
+/**
+ * @sub The subject of the user.
+ * @exp The interval between the expire date and 00:00:00 UTC on 1 January 1970.
+ */
 + (NSString *)idTokenWithSub:(NSString *)sub exp:(NSNumber *)exp;
 
 + (NSString *)idTokenWithSub:(NSString *)sub exp:(NSNumber *)exp fat:(BOOL)fat;


### PR DESCRIPTION
ID token requires the expire time to be relative to 1970. Right now we first generate the time that is relative to 2001 and then add the time interval between 2001 and 1970.
- (NSString *)idTokenWithExpireTime:(NSTimeInterval)expireTime {
  return [OIDTokenResponse idTokenWithSub:kUserID exp:@(expireTime + NSTimeIntervalSince1970)];
}

This PR is to simplify it by using 1970 as the reference date.