### PR TITLE
Add unit tests for GIDEMMSupport

### DIFF
--- a/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
@@ -1,0 +1,210 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <TargetConditionals.h>
+
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+
+#import <XCTest/XCTest.h>
+
+#import "GoogleSignIn/Sources/GIDEMMSupport.h"
+
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h"
+
+#import "GoogleSignIn/Sources/GIDEMMErrorHandler.h"
+#import "GoogleSignIn/Sources/GIDMDMPasscodeState.h"
+
+#ifdef SWIFT_PACKAGE
+@import AppAuth;
+@import GoogleUtilities_MethodSwizzler;
+@import GoogleUtilities_SwizzlerTestHelpers;
+@import OCMock;
+#else
+#import <GoogleUtilities/GULSwizzler.h>
+#import <GoogleUtilities/GULSwizzler+Unswizzle.h>
+#import <AppAuth/OIDError.h>
+#import <OCMock/OCMock.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+// The system name in old iOS versions.
+static NSString *const kOldIOSName = @"iPhone OS";
+
+// The system name in new iOS versions.
+static NSString *const kNewIOSName = @"iOS";
+
+@interface GIDEMMSupportTest : XCTestCase
+@end
+
+@implementation GIDEMMSupportTest
+
+- (void)testUpdatedEMMParametersWithParameters_NoEMM {
+  NSDictionary *originalParameters = @{
+    @"xyz" : @"xyz",
+  };
+
+  NSDictionary *updatedEMMParameters =
+      [GIDEMMSupport updatedEMMParametersWithParameters:originalParameters];
+
+  XCTAssertEqualObjects(updatedEMMParameters, originalParameters);
+}
+
+- (void)testUpdateEMMParametersWithParameters_systemName {
+  [GULSwizzler swizzleClass:[UIDevice class]
+                   selector:@selector(systemName)
+            isClassSelector:NO
+                  withBlock:^(id sender) { return kNewIOSName; }];
+
+  NSDictionary *originalParameters = @{
+    @"emm_support" : @"xyz",
+  };
+
+  NSDictionary *updatedEMMParameters =
+      [GIDEMMSupport updatedEMMParametersWithParameters:originalParameters];
+
+  NSDictionary *expectedParameters = @{
+    @"emm_support" : @"xyz",
+    @"device_os" : [NSString stringWithFormat:@"%@ %@",
+                    kNewIOSName, [UIDevice currentDevice].systemVersion]
+  };
+
+  XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);
+
+
+  [GULSwizzler unswizzleClass:[UIDevice class]
+                     selector:@selector(systemName)
+              isClassSelector:NO];
+}
+
+// When the systemName is @"iPhone OS" we still get "iOS".
+- (void)testUpdateEMMParametersWithParameters_systemNameNormalization {
+  [GULSwizzler swizzleClass:[UIDevice class]
+                    selector:@selector(systemName)
+             isClassSelector:NO
+                   withBlock:^(id sender) { return kOldIOSName; }];
+
+  NSDictionary *originalParameters = @{
+    @"emm_support" : @"xyz",
+  };
+
+  NSDictionary *updatedEMMParameters =
+      [GIDEMMSupport updatedEMMParametersWithParameters:originalParameters];
+
+  NSDictionary *expectedParameters = @{
+    @"emm_support" : @"xyz",
+    @"device_os" : [NSString stringWithFormat:@"%@ %@",
+                    kNewIOSName, [UIDevice currentDevice].systemVersion]
+  };
+
+  XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);
+
+
+  [GULSwizzler unswizzleClass:[UIDevice class]
+                     selector:@selector(systemName)
+              isClassSelector:NO];
+}
+
+- (void)testUpdateEMMParametersWithParameters_passcodInfo {
+  [GULSwizzler swizzleClass:[UIDevice class]
+                   selector:@selector(systemName)
+            isClassSelector:NO
+                  withBlock:^(id sender) { return kOldIOSName; }];
+
+  NSDictionary *originalParameters = @{
+    @"emm_support" : @"xyz",
+    @"device_os" : @"old one",
+    @"emm_passcode_info" : @"something",
+  };
+
+  NSDictionary *updatedEMMParameters =
+      [GIDEMMSupport updatedEMMParametersWithParameters:originalParameters];
+
+  NSDictionary *expectedParameters = @{
+    @"emm_support" : @"xyz",
+    @"device_os" : [NSString stringWithFormat:@"%@ %@",
+        kNewIOSName, [UIDevice currentDevice].systemVersion],
+    @"emm_passcode_info" : [GIDMDMPasscodeState passcodeState].info,
+  };
+
+  XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);
+
+  [GULSwizzler unswizzleClass:[UIDevice class]
+                     selector:@selector(systemName)
+              isClassSelector:NO];
+}
+
+- (void)testHandleTokenFetchEMMError_errorIsEMM {
+  // Set expectations.
+  NSDictionary *errorJSON = @{ @"error" : @"EMM Specific Error" };
+  NSError *emmError = [NSError errorWithDomain:@"anydomain"
+                                          code:12345
+                                      userInfo:@{ OIDOAuthErrorResponseErrorKey : errorJSON }];
+  id mockEMMErrorHandler = OCMStrictClassMock([GIDEMMErrorHandler class]);
+  [[[mockEMMErrorHandler stub] andReturn:mockEMMErrorHandler] sharedInstance];
+  __block void (^savedCompletion)(void);
+  [[[mockEMMErrorHandler expect] andReturnValue:@YES]
+      handleErrorFromResponse:errorJSON completion:[OCMArg checkWithBlock:^(id arg) {
+    savedCompletion = arg;
+    return YES;
+  }]];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Callback is called"];
+
+  [GIDEMMSupport handleTokenFetchEMMError:emmError completion:^(NSError *error) {
+    [expectation fulfill];
+    XCTAssertEqualObjects(error.domain, kGIDSignInErrorDomain);
+    XCTAssertEqual(error.code, kGIDSignInErrorCodeEMM);
+  }];
+
+  savedCompletion();
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+  [mockEMMErrorHandler verify];
+  [mockEMMErrorHandler stopMocking];
+}
+
+- (void)testHandleTokenFetchEMMError_errorIsNotEMM {
+  // Set expectations.
+  NSDictionary *errorJSON = @{ @"error" : @"Not EMM Specific Error" };
+  NSError *emmError = [NSError errorWithDomain:@"anydomain"
+                                          code:12345
+                                      userInfo:@{ OIDOAuthErrorResponseErrorKey : errorJSON }];
+  id mockEMMErrorHandler = OCMStrictClassMock([GIDEMMErrorHandler class]);
+  [[[mockEMMErrorHandler stub] andReturn:mockEMMErrorHandler] sharedInstance];
+  __block void (^savedCompletion)(void);
+  [[[mockEMMErrorHandler expect] andReturnValue:@NO]
+      handleErrorFromResponse:errorJSON completion:[OCMArg checkWithBlock:^(id arg) {
+    savedCompletion = arg;
+    return YES;
+  }]];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Callback is called"];
+
+  [GIDEMMSupport handleTokenFetchEMMError:emmError completion:^(NSError *error) {
+    [expectation fulfill];
+    XCTAssertEqualObjects(error.domain, @"anydomain");
+    XCTAssertEqual(error.code, 12345);
+  }];
+
+  savedCompletion();
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+  [mockEMMErrorHandler verify];
+  [mockEMMErrorHandler stopMocking];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
@@ -47,14 +47,19 @@ static NSString *const kOldIOSName = @"iPhone OS";
 // The system name in new iOS versions.
 static NSString *const kNewIOSName = @"iOS";
 
+// They keys in EMM dictionary.
+static NSString *const kEMMKey = @"emm_support";
+static NSString *const kDeviceOSKey = @"device_os";
+static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
+
 @interface GIDEMMSupportTest : XCTestCase
 @end
 
 @implementation GIDEMMSupportTest
 
-- (void)testUpdatedEMMParametersWithParameters_NoEMM {
+- (void)testUpdatedEMMParametersWithParameters_NoEMMKey {
   NSDictionary *originalParameters = @{
-    @"xyz" : @"xyz",
+    @"not_emm_support_key" : @"xyz",
   };
 
   NSDictionary *updatedEMMParameters =
@@ -70,7 +75,7 @@ static NSString *const kNewIOSName = @"iOS";
                   withBlock:^(id sender) { return kNewIOSName; }];
 
   NSDictionary *originalParameters = @{
-    @"emm_support" : @"xyz",
+    kEMMKey : @"xyz",
   };
 
   NSDictionary *updatedEMMParameters =
@@ -78,16 +83,17 @@ static NSString *const kNewIOSName = @"iOS";
 
   NSString *systemVersion = [UIDevice currentDevice].systemVersion;
   NSDictionary *expectedParameters = @{
-    @"emm_support" : @"xyz",
-    @"device_os" : [NSString stringWithFormat:@"%@ %@", kNewIOSName, systemVersion]
+    kEMMKey : @"xyz",
+    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@", kNewIOSName, systemVersion]
   };
 
   XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);
 
-
-  [GULSwizzler unswizzleClass:[UIDevice class]
-                     selector:@selector(systemName)
-              isClassSelector:NO];
+  [self addTeardownBlock:^{
+    [GULSwizzler unswizzleClass:[UIDevice class]
+                       selector:@selector(systemName)
+                isClassSelector:NO];
+  }];
 }
 
 // When the systemName is @"iPhone OS" we still get "iOS".
@@ -98,15 +104,15 @@ static NSString *const kNewIOSName = @"iOS";
                    withBlock:^(id sender) { return kOldIOSName; }];
 
   NSDictionary *originalParameters = @{
-    @"emm_support" : @"xyz",
+    kEMMKey : @"xyz",
   };
 
   NSDictionary *updatedEMMParameters =
       [GIDEMMSupport updatedEMMParametersWithParameters:originalParameters];
 
   NSDictionary *expectedParameters = @{
-    @"emm_support" : @"xyz",
-    @"device_os" : [NSString stringWithFormat:@"%@ %@",
+    kEMMKey : @"xyz",
+    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@",
                     kNewIOSName, [UIDevice currentDevice].systemVersion]
   };
 
@@ -125,19 +131,19 @@ static NSString *const kNewIOSName = @"iOS";
                   withBlock:^(id sender) { return kOldIOSName; }];
 
   NSDictionary *originalParameters = @{
-    @"emm_support" : @"xyz",
-    @"device_os" : @"old one",
-    @"emm_passcode_info" : @"something",
+    kEMMKey : @"xyz",
+    kDeviceOSKey : @"old one",
+    kEMMPasscodeInfoKey : @"something",
   };
 
   NSDictionary *updatedEMMParameters =
       [GIDEMMSupport updatedEMMParametersWithParameters:originalParameters];
 
   NSDictionary *expectedParameters = @{
-    @"emm_support" : @"xyz",
-    @"device_os" : [NSString stringWithFormat:@"%@ %@",
+    kEMMKey : @"xyz",
+    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@",
         kNewIOSName, [UIDevice currentDevice].systemVersion],
-    @"emm_passcode_info" : [GIDMDMPasscodeState passcodeState].info,
+    kEMMPasscodeInfoKey : [GIDMDMPasscodeState passcodeState].info,
   };
 
   XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);

--- a/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
@@ -81,10 +81,9 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
   NSDictionary *updatedEMMParameters =
       [GIDEMMSupport updatedEMMParametersWithParameters:originalParameters];
 
-  NSString *systemVersion = [UIDevice currentDevice].systemVersion;
   NSDictionary *expectedParameters = @{
     kEMMKey : @"xyz",
-    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@", kNewIOSName, systemVersion]
+    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@", kNewIOSName, [self systemVersion]]
   };
 
   XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);
@@ -112,8 +111,7 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
 
   NSDictionary *expectedParameters = @{
     kEMMKey : @"xyz",
-    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@",
-                    kNewIOSName, [UIDevice currentDevice].systemVersion]
+    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@", kNewIOSName, [self systemVersion]]
   };
 
   XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);
@@ -141,8 +139,7 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
 
   NSDictionary *expectedParameters = @{
     kEMMKey : @"xyz",
-    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@",
-        kNewIOSName, [UIDevice currentDevice].systemVersion],
+    kDeviceOSKey : [NSString stringWithFormat:@"%@ %@", kNewIOSName, [self systemVersion]],
     kEMMPasscodeInfoKey : [GIDMDMPasscodeState passcodeState].info,
   };
 
@@ -213,6 +210,12 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
   [self waitForExpectations:@[ notCalled ] timeout:1];
   savedCompletion();
   [self waitForExpectations:@[ called ] timeout:1];
+}
+
+# pragma mark - Helpers
+
+- (NSString *)systemVersion {
+  return [UIDevice currentDevice].systemVersion;
 }
 
 @end

--- a/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
@@ -116,10 +116,11 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
 
   XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);
 
-
-  [GULSwizzler unswizzleClass:[UIDevice class]
-                     selector:@selector(systemName)
-              isClassSelector:NO];
+  [self addTeardownBlock:^{
+    [GULSwizzler unswizzleClass:[UIDevice class]
+                       selector:@selector(systemName)
+                isClassSelector:NO];
+  }];
 }
 
 - (void)testUpdateEMMParametersWithParameters_passcodInfo {
@@ -145,9 +146,12 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
 
   XCTAssertEqualObjects(updatedEMMParameters, expectedParameters);
 
-  [GULSwizzler unswizzleClass:[UIDevice class]
-                     selector:@selector(systemName)
-              isClassSelector:NO];
+  [self addTeardownBlock:^{
+    [GULSwizzler unswizzleClass:[UIDevice class]
+                       selector:@selector(systemName)
+                isClassSelector:NO];
+  }];
+  
 }
 
 - (void)testHandleTokenFetchEMMError_errorIsEMM {


### PR DESCRIPTION
In the previous PR we created a utility class `GIDEMMSupport` to handle EMM related issues. This PR adds some unit tests for that class.