### PR TITLE
Fix the signInSample app

### DIFF
--- a/Samples/ObjC/SignInSample/Source/AuthInspectorViewController.m
+++ b/Samples/ObjC/SignInSample/Source/AuthInspectorViewController.m
@@ -36,13 +36,12 @@ static CGFloat const kTableViewCellPadding = 22.f;
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
     _keyPaths = @[
-      @"authentication.accessToken",
-      @"authentication.accessTokenExpirationDate",
-      @"authentication.refreshToken",
-      @"authentication.idToken",
+      @"accessToken.tokenString",
+      @"accessToken.expirationDate",
+      @"refreshToken.tokenString",
+      @"idToken.tokenString",
       @"grantedScopes",
       @"userID",
-      @"serverAuthCode",
       @"profile.email",
       @"profile.name",
     ];
@@ -140,4 +139,3 @@ static CGFloat const kTableViewCellPadding = 22.f;
 }
 
 @end
-

--- a/Samples/ObjC/SignInSample/Source/SignInViewController.m
+++ b/Samples/ObjC/SignInSample/Source/SignInViewController.m
@@ -248,7 +248,7 @@ static NSString *const kCredentialsButtonAccessibilityIdentifier = @"Credentials
 
 - (IBAction)signIn:(id)sender {
   [GIDSignIn.sharedInstance signInWithPresentingViewController:self
-                                                    completion:^(GIDGoogleUser *user,
+                                                    completion:^(GIDUserAuth *userAuth,
                                                                  NSError *error) {
     if (error) {
       self->_signInAuthStatus.text =


### PR DESCRIPTION
Since we refactored the GIDGoogleUser API we need to update the property name list in the `AuthInspectorViewController`. Otherwise there will be no content displayed in the view.