### PR TITLE
Improve our workflows

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,7 +11,7 @@ jobs:
 
   swift-button-functional-test:
     runs-on: macOS-12
-    if: !github.event.pull_request.head.repo.fork
+    if: "!github.event.pull_request.head.repo.fork"
     defaults:
       run:
         working-directory: Samples/Swift/DaysUntilBirthday

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,6 +11,7 @@ jobs:
 
   swift-button-functional-test:
     runs-on: macOS-12
+    if: !github.event.pull_request.head.repo.fork
     defaults:
       run:
         working-directory: Samples/Swift/DaysUntilBirthday

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,6 +11,7 @@ jobs:
 
   swift-button-functional-test:
     runs-on: macOS-12
+    # Don't run if triggered by a PR from a fork since our Secrets won't be provided to the runner.
     if: "!github.event.pull_request.head.repo.fork"
     defaults:
       run:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   swift-button-functional-test:
-    runs-on: macOS-latest
+    runs-on: macOS-12
     defaults:
       run:
         working-directory: Samples/Swift/DaysUntilBirthday

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This addresses three issues:

- The `pull_request` trigger is currently scoped to `main` branch only, so jobs aren't run by default for PRs on feature branches.
- Warnings about the`macOS-latest` runner alias transitioning from `macOS-11` to `macOS-12`.
- Integration tests failing when triggered by a PR from a fork due to the secret not being passed to the runner in [this scenario](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories).