### PR TITLE
Update iOS support version

### DIFF
--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -12,7 +12,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
     :git => 'https://github.com/google/GoogleSignIn-iOS.git',
     :tag => s.version.to_s
   }
-  ios_deployment_target = '9.0'
+  ios_deployment_target = '10.0'
   osx_deployment_target = '10.15'
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
   defaultLocalization: "en",
   platforms: [
     .macOS(.v10_15),
-    .iOS(.v9)
+    .iOS(.v10)
   ],
   products: [
     .library(


### PR DESCRIPTION
The package product 'GTMSessionFetcherCore' had a new release recently and requires minimum platform version 10.0 for the iOS platform.