### PR TITLE
Remove `GIDDisconnectCompletion`

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -384,7 +384,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   [self removeAllKeychainEntries];
 }
 
-- (void)disconnectWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
+- (void)disconnectWithCompletion:(nullable GIDDisconnectCompletion)completion {
   OIDAuthState *authState = _currentUser.authState;
   if (!authState) {
     // Even the user is not signed in right now, we still need to remove any token saved in the

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -384,7 +384,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   [self removeAllKeychainEntries];
 }
 
-- (void)disconnectWithCompletion:(nullable GIDDisconnectCompletion)completion {
+- (void)disconnectWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
   OIDAuthState *authState = _currentUser.authState;
   if (!authState) {
     // Even the user is not signed in right now, we still need to remove any token saved in the

--- a/GoogleSignIn/Sources/GIDSignIn_Private.h
+++ b/GoogleSignIn/Sources/GIDSignIn_Private.h
@@ -33,6 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// was unsuccessful.
 typedef void (^GIDUserAuthCompletion)(GIDUserAuth *_Nullable userAuth, NSError *_Nullable error);
 
+/// Represents a completion block that takes an error if the operation was unsuccessful.
+typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
+
 // Private |GIDSignIn| methods that are used internally in this SDK and other Google SDKs.
 @interface GIDSignIn ()
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -51,9 +51,6 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
   kGIDSignInErrorCodeMismatchWithCurrentUser = -9,
 };
 
-/// Represents a completion block that takes an error if the operation was unsuccessful.
-typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
-
 /// This class signs the user in with Google.
 ///
 /// For reference, please see "Google Sign-In for iOS" at
@@ -102,9 +99,9 @@ typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
 /// Disconnects the current user from the app and revokes previous authentication. If the operation
 /// succeeds, the OAuth 2.0 token is also removed from keychain.
 ///
-/// @param completion The optional `GIDDisconnectCompletion` block that is called on completion.
+/// @param completion The optional block that is called on completion.
 ///     This block will be called asynchronously on the main queue.
-- (void)disconnectWithCompletion:(nullable GIDDisconnectCompletion)completion;
+- (void)disconnectWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;
 
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 /// Starts an interactive sign-in flow on iOS.


### PR DESCRIPTION
For consistency with the rest of our completion block typedef removals from public headers.