### PR TITLE
Use a consistent approach to extension availability

### DIFF
--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDGoogleUser.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDGoogleUser.h
@@ -112,7 +112,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addScopes:(NSArray<NSString *> *)scopes
     presentingWindow:(NSWindow *)presentingWindow
           completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                        NSError *_Nullable error))completion;
+                                        NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The add scopes flow is not supported in App Extensions.");
 
 #endif
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDGoogleUser.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDGoogleUser.h
@@ -112,8 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addScopes:(NSArray<NSString *> *)scopes
     presentingWindow:(NSWindow *)presentingWindow
           completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                        NSError *_Nullable error))completion
-    NS_EXTENSION_UNAVAILABLE("The add scopes flow is not supported in App Extensions.");
+                                        NSError *_Nullable error))completion;
 
 #endif
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -176,8 +176,7 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 ///     be called asynchronously on the main queue.
 - (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
                         completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                                      NSError *_Nullable error))completion
-    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+                                                      NSError *_Nullable error))completion;
 
 /// Starts an interactive sign-in flow on macOS using the provided hint.
 ///
@@ -194,8 +193,7 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 - (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
                               hint:(nullable NSString *)hint
                         completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                                      NSError *_Nullable error))completion
-    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+                                                      NSError *_Nullable error))completion;
 
 /// Starts an interactive sign-in flow on macOS using the provided hint.
 ///
@@ -214,8 +212,7 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
                               hint:(nullable NSString *)hint
                   additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
                         completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                                      NSError *_Nullable error))completion
-    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+                                                      NSError *_Nullable error))completion;
 
 #endif
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -160,7 +160,8 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
                                       hint:(nullable NSString *)hint
                           additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
                                 completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                                              NSError *_Nullable error))completion;
+                                                              NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
 #elif TARGET_OS_OSX
 /// Starts an interactive sign-in flow on macOS.
@@ -175,7 +176,8 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 ///     be called asynchronously on the main queue.
 - (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
                         completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                                      NSError *_Nullable error))completion;
+                                                      NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
 /// Starts an interactive sign-in flow on macOS using the provided hint.
 ///
@@ -192,7 +194,8 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 - (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
                               hint:(nullable NSString *)hint
                         completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                                      NSError *_Nullable error))completion;
+                                                      NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
 /// Starts an interactive sign-in flow on macOS using the provided hint.
 ///
@@ -211,7 +214,8 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
                               hint:(nullable NSString *)hint
                   additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
                         completion:(nullable void (^)(GIDUserAuth *_Nullable userAuth,
-                                                      NSError *_Nullable error))completion;
+                                                      NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
 #endif
 


### PR DESCRIPTION
We forgot to use the `NS_EXTENSION_UNAVAILABLE` macro on the new iOS variant of the `signIn:` method.