### PR TITLE
Add GIDProfileDataFetcher

### DIFF
--- a/GoogleSignIn/Sources/GIDProfileData.m
+++ b/GoogleSignIn/Sources/GIDProfileData.m
@@ -138,21 +138,22 @@ NSString *const kBasicProfileFamilyNameKey = @"family_name";
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)decoder {
-  self = [super init];
-  if (self) {
-    _email = [decoder decodeObjectOfClass:[NSString class] forKey:kEmailKey];
-    _name = [decoder decodeObjectOfClass:[NSString class] forKey:kNameKey];
-    _givenName = [decoder decodeObjectOfClass:[NSString class] forKey:kGivenNameKey];
-    _familyName = [decoder decodeObjectOfClass:[NSString class] forKey:kFamilyNameKey];
-    _imageURL = [decoder decodeObjectOfClass:[NSURL class] forKey:kImageURLKey];
+  NSString *email = [decoder decodeObjectOfClass:[NSString class] forKey:kEmailKey];
+  NSString *name = [decoder decodeObjectOfClass:[NSString class] forKey:kNameKey];
+  NSString *givenName = [decoder decodeObjectOfClass:[NSString class] forKey:kGivenNameKey];
+  NSString *familyName = [decoder decodeObjectOfClass:[NSString class] forKey:kFamilyNameKey];
+  NSURL *imageURL = [decoder decodeObjectOfClass:[NSURL class] forKey:kImageURLKey];
 
-    // Check to see if this is an old archive, if so, try decoding the old image URL string key.
-    if ([decoder containsValueForKey:kOldImageURLStringKey]) {
-      _imageURL = [NSURL URLWithString:[decoder decodeObjectOfClass:[NSString class]
-                                                             forKey:kOldImageURLStringKey]];
-    }
+  // Check to see if this is an old archive, if so, try decoding the old image URL string key.
+  if ([decoder containsValueForKey:kOldImageURLStringKey]) {
+    imageURL = [NSURL URLWithString:[decoder decodeObjectOfClass:[NSString class]
+                                                           forKey:kOldImageURLStringKey]];
   }
-  return self;
+  
+  return [self initWithEmail:email
+                        name:name givenName:givenName
+                  familyName:familyName
+                    imageURL:imageURL];
 }
 
 - (void)encodeWithCoder:(NSCoder *)encoder {

--- a/GoogleSignIn/Sources/GIDProfileData.m
+++ b/GoogleSignIn/Sources/GIDProfileData.m
@@ -128,7 +128,8 @@ static NSString *const kOldImageURLStringKey = @"picture";
   }
   
   return [self initWithEmail:email
-                        name:name givenName:givenName
+                        name:name
+                   givenName:givenName
                   familyName:familyName
                     imageURL:imageURL];
 }

--- a/GoogleSignIn/Sources/GIDProfileData.m
+++ b/GoogleSignIn/Sources/GIDProfileData.m
@@ -32,13 +32,6 @@ static NSString *const kFamilyNameKey = @"family_name";
 static NSString *const kImageURLKey = @"image_url";
 static NSString *const kOldImageURLStringKey = @"picture";
 
-// Basic profile (Fat ID Token / userinfo endpoint) keys
-NSString *const kBasicProfileEmailKey = @"email";
-NSString *const kBasicProfilePictureKey = @"picture";
-NSString *const kBasicProfileNameKey = @"name";
-NSString *const kBasicProfileGivenNameKey = @"given_name";
-NSString *const kBasicProfileFamilyNameKey = @"family_name";
-
 @implementation GIDProfileData {
   NSURL *_imageURL;
 }
@@ -57,22 +50,6 @@ NSString *const kBasicProfileFamilyNameKey = @"family_name";
     _imageURL = [imageURL copy];
   }
   return self;
-}
-
-- (nullable instancetype)initWithIDToken:(OIDIDToken *)idToken {
-  if (!idToken ||
-      !idToken.claims[kBasicProfilePictureKey] ||
-      !idToken.claims[kBasicProfileNameKey] ||
-      !idToken.claims[kBasicProfileGivenNameKey] ||
-      !idToken.claims[kBasicProfileFamilyNameKey]) {
-    return nil;
-  }
-
-  return [self initWithEmail:idToken.claims[kBasicProfileEmailKey]
-                        name:idToken.claims[kBasicProfileNameKey]
-                   givenName:idToken.claims[kBasicProfileGivenNameKey]
-                  familyName:idToken.claims[kBasicProfileFamilyNameKey]
-                    imageURL:[NSURL URLWithString:idToken.claims[kBasicProfilePictureKey]]];
 }
 
 - (BOOL)hasImage {

--- a/GoogleSignIn/Sources/GIDProfileData.m
+++ b/GoogleSignIn/Sources/GIDProfileData.m
@@ -59,7 +59,7 @@ NSString *const kBasicProfileFamilyNameKey = @"family_name";
   return self;
 }
 
-- (instancetype)initWithIDToken:(OIDIDToken *)idToken {
+- (nullable instancetype)initWithIDToken:(OIDIDToken *)idToken {
   if (!idToken ||
       !idToken.claims[kBasicProfilePictureKey] ||
       !idToken.claims[kBasicProfileNameKey] ||
@@ -68,12 +68,11 @@ NSString *const kBasicProfileFamilyNameKey = @"family_name";
     return nil;
   }
 
-  return [[GIDProfileData alloc]
-      initWithEmail:idToken.claims[kBasicProfileEmailKey]
-               name:idToken.claims[kBasicProfileNameKey]
-          givenName:idToken.claims[kBasicProfileGivenNameKey]
-         familyName:idToken.claims[kBasicProfileFamilyNameKey]
-           imageURL:[NSURL URLWithString:idToken.claims[kBasicProfilePictureKey]]];
+  return [self initWithEmail:idToken.claims[kBasicProfileEmailKey]
+                        name:idToken.claims[kBasicProfileNameKey]
+                   givenName:idToken.claims[kBasicProfileGivenNameKey]
+                  familyName:idToken.claims[kBasicProfileFamilyNameKey]
+                    imageURL:[NSURL URLWithString:idToken.claims[kBasicProfilePictureKey]]];
 }
 
 - (BOOL)hasImage {

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class OIDAuthState;
+@class GIDProfileData;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol GIDProfileDataFetcher <NSObject>
+
+/// Fetches the latest @GIDProfileData object.
+///
+/// @param authState The state of the current OAuth session.
+/// @param completion The block that is called on completion asynchronously.
+- (void)fetchProfileDataWithAuthState:(OIDAuthState *)authState
+                           completion:(void (^)(GIDProfileData *_Nullable profileData,
+                                                NSError *_Nullable error))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
@@ -17,13 +17,14 @@
 #import <Foundation/Foundation.h>
 
 @class OIDAuthState;
+@class OIDIDToken;
 @class GIDProfileData;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol GIDProfileDataFetcher <NSObject>
 
-/// Fetches the latest @GIDProfileData object.
+/// Fetches the latest `GIDProfileData` object.
 ///
 /// "This method either extracts profile data from `OIDIDToken` in `OIDAuthState` or fetches it
 /// from the UserInfo endpoint."
@@ -33,6 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)fetchProfileDataWithAuthState:(OIDAuthState *)authState
                            completion:(void (^)(GIDProfileData *_Nullable profileData,
                                                 NSError *_Nullable error))completion;
+
+/// Fetches the latest `GIDProfileData` object.
+///
+/// @param idToken The ID token.
+- (nullable GIDProfileData*)fetchProfileDataWithIDToken:(OIDIDToken *)idToken;
 
 @end
 

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Fetches the latest @GIDProfileData object.
 ///
 /// This method either extracts the profile data out of the OIDAuthState object or fetches it
-/// from the Google user Info server.
+/// from the Google user info server.
 ///
 /// @param authState The state of the current OAuth session.
 /// @param completion The block that is called on completion asynchronously.

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Fetches the latest @GIDProfileData object.
 ///
-/// This method either extracts the profile data out of the OIDAuthState object or fetches it
-/// from the Google user info server.
+/// "This method either extracts profile data from `OIDIDToken` in `OIDAuthState` or fetches it
+/// from the UserInfo endpoint."
 ///
 /// @param authState The state of the current OAuth session.
 /// @param completion The block that is called on completion asynchronously.

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol GIDProfileDataFetcher <NSObject>
 
 /// Fetches the latest @GIDProfileData object.
+///
+/// This method either extracts the profile data out of the OIDAuthState object or fetches it
+/// from the Google user Info server.
 ///
 /// @param authState The state of the current OAuth session.
 /// @param completion The block that is called on completion asynchronously.

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h
@@ -26,8 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Fetches the latest `GIDProfileData` object.
 ///
-/// "This method either extracts profile data from `OIDIDToken` in `OIDAuthState` or fetches it
-/// from the UserInfo endpoint."
+/// This method either extracts profile data from `OIDIDToken` in `OIDAuthState` or fetches it
+/// from the UserInfo endpoint.
 ///
 /// @param authState The state of the current OAuth session.
 /// @param completion The block that is called on completion asynchronously.
@@ -35,10 +35,13 @@ NS_ASSUME_NONNULL_BEGIN
                            completion:(void (^)(GIDProfileData *_Nullable profileData,
                                                 NSError *_Nullable error))completion;
 
-/// Fetches the latest `GIDProfileData` object.
+/// Fetches a `GIDProfileData` object from an ID token.
+///
+/// This method returns  a `GIDProfileData` object if the ID token is a fat one. Otherwise, returns
+/// nil.
 ///
 /// @param idToken The ID token.
-- (nullable GIDProfileData*)fetchProfileDataWithIDToken:(OIDIDToken *)idToken;
+- (nullable GIDProfileData *)fetchProfileDataWithIDToken:(OIDIDToken *)idToken;
 
 @end
 

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h
@@ -18,8 +18,6 @@
 
 #import "GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h"
 
-@class OIDIDToken;
-
 @protocol GIDHTTPFetcher;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface GIDProfileDataFetcher : NSObject<GIDProfileDataFetcher>
+@interface GIDProfileDataFetcher : NSObject <GIDProfileDataFetcher>
 
 /// The convenience initializer.
 - (instancetype)init;
 
 /// The initializer for unit test.
-- (instancetype)initWithDataFetcher:(id<GIDHTTPFetcher>)httpFetcher NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithHTTPFetcher:(id<GIDHTTPFetcher>)httpFetcher NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "GoogleSignIn/Sources/GIDProfileDataFetcher/API/GIDProfileDataFetcher.h"
+
+@class OIDIDToken;
+
+@protocol GIDHTTPFetcher;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GIDProfileDataFetcher : NSObject<GIDProfileDataFetcher>
+
+/// The convenience initializer.
+- (instancetype)init;
+
+/// The initializer for unit test.
+- (instancetype)initWithDataFetcher:(id<GIDHTTPFetcher>)httpFetcher NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
@@ -24,10 +24,10 @@ static NSString *const kUserInfoURLTemplate = @"https://%@/oauth2/v3/userinfo";
 
 - (instancetype)init {
   GIDHTTPFetcher *httpFetcher = [[GIDHTTPFetcher alloc] init];
-  return [self initWithDataFetcher:httpFetcher];
+  return [self initWithHTTPFetcher:httpFetcher];
 }
 
-- (instancetype)initWithDataFetcher:(id<GIDHTTPFetcher>)httpFetcher {
+- (instancetype)initWithHTTPFetcher:(id<GIDHTTPFetcher>)httpFetcher {
   self = [super init];
   if (self) {
     _httpFetcher = httpFetcher;

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
@@ -66,8 +66,10 @@ static NSString *const kBasicProfileFamilyNameKey = @"family_name";
   // If profile data is present in the ID token, use it.
   if (idToken) {
     GIDProfileData *profileData = [self fetchProfileDataWithIDToken:idToken];
-    completion(profileData, nil);
-    return;
+    if (profileData) {
+      completion(profileData, nil);
+      return;
+    }
   }
   
   // If we can't retrieve profile data from the ID token, make a UserInfo endpoint request to

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #import "GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h"
 
 #import "GoogleSignIn/Sources/GIDHTTPFetcher/API/GIDHTTPFetcher.h"
@@ -40,14 +56,15 @@ static NSString *const kUserInfoURLTemplate = @"https://%@/oauth2/v3/userinfo";
                                                 NSError *_Nullable error))completion {
   OIDIDToken *idToken =
       [[OIDIDToken alloc] initWithIDTokenString:authState.lastTokenResponse.idToken];
-  // If the profile data are present in the ID token, use them.
+  // If profile data is present in the ID token, use it.
   if (idToken) {
     GIDProfileData *profileData = [[GIDProfileData alloc] initWithIDToken:idToken];
     completion(profileData, nil);
     return;
   }
   
-  // If we can't retrieve profile data from the ID token, make a userInfo request to fetch them.
+  // If we can't retrieve profile data from the ID token, make a UserInfo endpoint request to
+  // fetch it.
   NSString *infoString = [NSString stringWithFormat:kUserInfoURLTemplate,
                              [GIDSignInPreferences googleUserInfoServer]];
   NSURL *infoURL = [NSURL URLWithString:infoString];

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
@@ -63,8 +63,8 @@ static NSString *const kBasicProfileFamilyNameKey = @"family_name";
                                                 NSError *_Nullable error))completion {
   OIDIDToken *idToken =
       [[OIDIDToken alloc] initWithIDTokenString:authState.lastTokenResponse.idToken];
-  // If profile data is present in the ID token, use it.
   if (idToken) {
+    // If we have an ID token, try to extract profile data from it.
     GIDProfileData *profileData = [self fetchProfileDataWithIDToken:idToken];
     if (profileData) {
       completion(profileData, nil);

--- a/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
+++ b/GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.m
@@ -1,0 +1,87 @@
+#import "GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h"
+
+#import "GoogleSignIn/Sources/GIDHTTPFetcher/API/GIDHTTPFetcher.h"
+#import "GoogleSignIn/Sources/GIDHTTPFetcher/Implementations/GIDHTTPFetcher.h"
+#import "GoogleSignIn/Sources/GIDProfileData_Private.h"
+#import "GoogleSignIn/Sources/GIDSignInPreferences.h"
+
+#ifdef SWIFT_PACKAGE
+@import AppAuth;
+@import GTMAppAuth;
+#else
+#import <AppAuth/AppAuth.h>
+#import <GTMAppAuth/GTMAppAuth.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+// The URL template for the URL to get user info.
+static NSString *const kUserInfoURLTemplate = @"https://%@/oauth2/v3/userinfo";
+
+@implementation GIDProfileDataFetcher {
+  id<GIDHTTPFetcher> _httpFetcher;
+}
+
+- (instancetype)init {
+  GIDHTTPFetcher *httpFetcher = [[GIDHTTPFetcher alloc] init];
+  return [self initWithDataFetcher:httpFetcher];
+}
+
+- (instancetype)initWithDataFetcher: (id<GIDHTTPFetcher>)httpFetcher {
+  self = [super init];
+  if (self) {
+    _httpFetcher = httpFetcher;
+  }
+  return self;
+}
+
+- (void)fetchProfileDataWithAuthState:(OIDAuthState *)authState
+                           completion:(void (^)(GIDProfileData *_Nullable profileData,
+                                                NSError *_Nullable error))completion {
+  OIDIDToken *idToken =
+      [[OIDIDToken alloc] initWithIDTokenString:authState.lastTokenResponse.idToken];
+  // If the profile data are present in the ID token, use them.
+  if (idToken) {
+    GIDProfileData *profileData = [[GIDProfileData alloc]initWithIDToken:idToken];
+    completion(profileData, nil);
+    return;
+  }
+  // If we can't retrieve profile data from the ID token, make a userInfo request to fetch them.
+  NSString *infoString = [NSString stringWithFormat:kUserInfoURLTemplate,
+                             [GIDSignInPreferences googleUserInfoServer]];
+  NSURL *infoURL = [NSURL URLWithString:infoString];
+  NSMutableURLRequest *infoRequest = [NSMutableURLRequest requestWithURL:infoURL];
+  GTMAppAuthFetcherAuthorization *authorization =
+      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:authState];
+  
+  [_httpFetcher fetchURLRequest:infoRequest
+                 withAuthorizer:authorization
+                    withComment:@"GIDSignIn: fetch basic profile info"
+                     completion:^(NSData *data, NSError *error) {
+    if (error) {
+      completion(nil, error);
+    } else {
+      NSError *jsonDeserializationError;
+      NSDictionary<NSString *, NSString *> *profileDict =
+        [NSJSONSerialization JSONObjectWithData:data
+                                        options:NSJSONReadingMutableContainers
+                                          error:&jsonDeserializationError];
+      if (profileDict) {
+        GIDProfileData *profileData = [[GIDProfileData alloc]
+            initWithEmail:idToken.claims[kBasicProfileEmailKey]
+                     name:profileDict[kBasicProfileNameKey]
+                givenName:profileDict[kBasicProfileGivenNameKey]
+               familyName:profileDict[kBasicProfileFamilyNameKey]
+                 imageURL:[NSURL URLWithString:profileDict[kBasicProfilePictureKey]]];
+        completion(profileData, nil);
+      }
+      else {
+        completion(nil, jsonDeserializationError);
+      }
+    }
+  }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/GIDProfileData_Private.h
+++ b/GoogleSignIn/Sources/GIDProfileData_Private.h
@@ -34,10 +34,10 @@ extern NSString *const kBasicProfileFamilyNameKey;
                          name:(NSString *)name
                     givenName:(nullable NSString *)givenName
                    familyName:(nullable NSString *)familyName
-                     imageURL:(nullable NSURL *)imageURL;
+                     imageURL:(nullable NSURL *)imageURL NS_DESIGNATED_INITIALIZER;
 
 /// Initialize with id token.
-- (instancetype)initWithIDToken:(OIDIDToken *)idToken;
+- (nullable instancetype)initWithIDToken:(OIDIDToken *)idToken;
 
 @end
 

--- a/GoogleSignIn/Sources/GIDProfileData_Private.h
+++ b/GoogleSignIn/Sources/GIDProfileData_Private.h
@@ -16,7 +16,15 @@
 
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDProfileData.h"
 
+@class OIDIDToken;
+
 NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const kBasicProfileEmailKey;
+extern NSString *const kBasicProfilePictureKey;
+extern NSString *const kBasicProfileNameKey;
+extern NSString *const kBasicProfileGivenNameKey;
+extern NSString *const kBasicProfileFamilyNameKey;
 
 // Private |GIDProfileData| methods that are used in this SDK.
 @interface GIDProfileData ()
@@ -27,6 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
                     givenName:(nullable NSString *)givenName
                    familyName:(nullable NSString *)familyName
                      imageURL:(nullable NSURL *)imageURL;
+
+/// Initialize with id token.
+- (instancetype)initWithIDToken:(OIDIDToken *)idToken;
 
 @end
 

--- a/GoogleSignIn/Sources/GIDProfileData_Private.h
+++ b/GoogleSignIn/Sources/GIDProfileData_Private.h
@@ -39,6 +39,8 @@ extern NSString *const kBasicProfileFamilyNameKey;
 /// Initialize with id token.
 - (nullable instancetype)initWithIDToken:(OIDIDToken *)idToken;
 
+- (instancetype)init NS_UNAVAILABLE; 
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/GIDProfileData_Private.h
+++ b/GoogleSignIn/Sources/GIDProfileData_Private.h
@@ -16,15 +16,7 @@
 
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDProfileData.h"
 
-@class OIDIDToken;
-
 NS_ASSUME_NONNULL_BEGIN
-
-extern NSString *const kBasicProfileEmailKey;
-extern NSString *const kBasicProfilePictureKey;
-extern NSString *const kBasicProfileNameKey;
-extern NSString *const kBasicProfileGivenNameKey;
-extern NSString *const kBasicProfileFamilyNameKey;
 
 // Private |GIDProfileData| methods that are used in this SDK.
 @interface GIDProfileData ()
@@ -35,9 +27,6 @@ extern NSString *const kBasicProfileFamilyNameKey;
                     givenName:(nullable NSString *)givenName
                    familyName:(nullable NSString *)familyName
                      imageURL:(nullable NSURL *)imageURL NS_DESIGNATED_INITIALIZER;
-
-/// Initialize with ID token.
-- (nullable instancetype)initWithIDToken:(OIDIDToken *)idToken;
 
 @end
 

--- a/GoogleSignIn/Sources/GIDProfileData_Private.h
+++ b/GoogleSignIn/Sources/GIDProfileData_Private.h
@@ -36,10 +36,8 @@ extern NSString *const kBasicProfileFamilyNameKey;
                    familyName:(nullable NSString *)familyName
                      imageURL:(nullable NSURL *)imageURL NS_DESIGNATED_INITIALIZER;
 
-/// Initialize with id token.
+/// Initialize with ID token.
 - (nullable instancetype)initWithIDToken:(OIDIDToken *)idToken;
-
-- (instancetype)init NS_UNAVAILABLE; 
 
 @end
 

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -466,7 +466,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 
 - (instancetype)initWithKeychainHandler:(id<GIDKeychainHandler>)keychainHandler
                             httpFetcher:(id<GIDHTTPFetcher>)httpFetcher
-                     profileDataFetcher:(id<GIDProfileDataFetcher>)profileDataFetcher{
+                     profileDataFetcher:(id<GIDProfileDataFetcher>)profileDataFetcher {
   self = [super init];
   if (self) {
     // Get the bundle of the current executable.

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -824,9 +824,9 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
     [handlerAuthFlow wait];
     
     [self->_profileDataFetcher
-            fetchProfileDataWithAuthState:(OIDAuthState *)authState
-                               completion:^(GIDProfileData *_Nullable profileData,
-                                            NSError *_Nullable error) {
+        fetchProfileDataWithAuthState:(OIDAuthState *)authState
+                           completion:^(GIDProfileData *_Nullable profileData,
+                                        NSError *_Nullable error) {
       if (error) {
         handlerAuthFlow.error = error;
       } else {

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -76,9 +76,6 @@ NS_ASSUME_NONNULL_BEGIN
 // The name of the query parameter used for logging the restart of auth from EMM callback.
 static NSString *const kEMMRestartAuthParameter = @"emmres";
 
-// The URL template for the URL to get user info.
-static NSString *const kUserInfoURLTemplate = @"https://%@/oauth2/v3/userinfo";
-
 // The URL template for the URL to revoke the token.
 static NSString *const kRevokeTokenURLTemplate = @"https://%@/o/oauth2/revoke";
 

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -219,7 +219,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   // Restore current user without refreshing the access token.
   OIDIDToken *idToken =
       [[OIDIDToken alloc] initWithIDTokenString:authState.lastTokenResponse.idToken];
-  GIDProfileData *profileData = [[GIDProfileData alloc] initWithIDToken:idToken];
+  GIDProfileData *profileData = [_profileDataFetcher fetchProfileDataWithIDToken:idToken];
 
   GIDGoogleUser *user = [[GIDGoogleUser alloc] initWithAuthState:authState profileData:profileData];
   self.currentUser = user;

--- a/GoogleSignIn/Sources/GIDSignIn_Private.h
+++ b/GoogleSignIn/Sources/GIDSignIn_Private.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol GIDHTTPFetcher;
 @protocol GIDKeychainHandler;
+@protocol GIDProfileDataFetcher;
 
 /// Represents a completion block that takes a `GIDSignInResult` on success or an error if the
 /// operation was unsuccessful.
@@ -52,6 +53,7 @@ typedef void (^GIDDisconnectCompletion)(NSError *_Nullable error);
 /// The designated initializer.
 - (instancetype)initWithKeychainHandler:(id<GIDKeychainHandler>)keychainHandler
                             httpFetcher:(id<GIDHTTPFetcher>)HTTPFetcher
+                     profileDataFetcher:(id<GIDProfileDataFetcher>)profileDataFetcher
     NS_DESIGNATED_INITIALIZER;
 
 /// Authenticates with extra options.

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDProfileData.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDProfileData.h
@@ -42,6 +42,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return The URL of the user's profile image.
 - (nullable NSURL *)imageURLWithDimension:(NSUInteger)dimension;
 
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDProfileData.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDProfileData.h
@@ -36,15 +36,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// Whether or not the user has profile image.
 @property(nonatomic, readonly) BOOL hasImage;
 
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Gets the user's profile image URL for the given dimension in pixels for each side of the square.
 ///
 /// @param dimension The desired height (and width) of the profile image.
 /// @return The URL of the user's profile image.
 - (nullable NSURL *)imageURLWithDimension:(NSUInteger)dimension;
-
-- (instancetype)init NS_UNAVAILABLE;
-
-+ (instancetype)new NS_UNAVAILABLE;
 
 @end
 

--- a/GoogleSignIn/Tests/Unit/GIDProfileDataFetcherTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDProfileDataFetcherTest.m
@@ -36,7 +36,7 @@ static NSInteger const kErrorCode = 400;
 - (void)setUp {
   [super setUp];
   _httpFetcher = [[GIDFakeHTTPFetcher alloc] init];
-  _profileDataFetcher = [[GIDProfileDataFetcher alloc] initWithDataFetcher:_httpFetcher];
+  _profileDataFetcher = [[GIDProfileDataFetcher alloc] initWithHTTPFetcher:_httpFetcher];
 }
 
 - (void)testFetchProfileData_outOfAuthState_success {

--- a/GoogleSignIn/Tests/Unit/GIDProfileDataFetcherTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDProfileDataFetcherTest.m
@@ -1,0 +1,150 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+// Test module imports
+@import GoogleSignIn;
+
+#import "GoogleSignIn/Sources/GIDHTTPFetcher/Implementations/Fakes/GIDFakeHTTPFetcher.h"
+#import "GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h"
+#import "GoogleSignIn/Tests/Unit/OIDAuthState+Testing.h"
+#import "GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h"
+
+static NSString *const kErrorDomain = @"ERROR_DOMAIN";
+static NSInteger const kErrorCode = 400;
+
+@interface GIDProfileDataFetcherTest : XCTestCase
+@end
+
+@implementation GIDProfileDataFetcherTest {
+  GIDProfileDataFetcher *_profileDataFetcher;
+  GIDFakeHTTPFetcher *_httpFetcher;
+}
+
+- (void)setUp {
+  [super setUp];
+  _httpFetcher = [[GIDFakeHTTPFetcher alloc] init];
+  _profileDataFetcher = [[GIDProfileDataFetcher alloc] initWithDataFetcher:_httpFetcher];
+}
+
+- (void)testFetchProfileData_outOfAuthState_success {
+  OIDTokenResponse *tokenResponse =
+      [OIDTokenResponse testInstanceWithIDToken:[OIDTokenResponse fatIDToken]
+                                    accessToken:kAccessToken
+                                      expiresIn:@(300)
+                                   refreshToken:kRefreshToken
+                                   tokenRequest:nil];
+  OIDAuthState *authState = [OIDAuthState testInstanceWithTokenResponse:tokenResponse];
+  
+  GIDHTTPFetcherTestBlock testBlock =
+      ^(NSURLRequest *request, GIDHTTPFetcherFakeResponseProviderBlock responseProvider) {
+        XCTFail(@"_httpFetcher should not be invoked");
+      };
+  [_httpFetcher setTestBlock:testBlock];
+  
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Callback called with no error"];
+  
+  [_profileDataFetcher
+      fetchProfileDataWithAuthState:authState
+                         completion:^(GIDProfileData *profileData, NSError *error) {
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(profileData.name, kFatName);
+    XCTAssertEqualObjects(profileData.givenName, kFatGivenName);
+    XCTAssertEqualObjects(profileData.familyName, kFatFamilyName);
+    XCTAssertTrue(profileData.hasImage);
+    [expectation fulfill];
+  }];
+  
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testFetchProfileData_fromInfoURL_fetchingError {
+  OIDTokenResponse *tokenResponse =
+      [OIDTokenResponse testInstanceWithIDToken:nil
+                                    accessToken:kAccessToken
+                                      expiresIn:@(300)
+                                   refreshToken:kRefreshToken
+                                   tokenRequest:nil];
+  OIDAuthState *authState = [OIDAuthState testInstanceWithTokenResponse:tokenResponse];
+  
+  XCTestExpectation *fetcherExpectation =
+      [self expectationWithDescription:@"_httpFetcher is invoked"];
+  GIDHTTPFetcherTestBlock testBlock =
+      ^(NSURLRequest *request, GIDHTTPFetcherFakeResponseProviderBlock responseProvider) {
+        NSError *fetchingError = [self error];
+        responseProvider(nil, fetchingError);
+        [fetcherExpectation fulfill];
+      };
+  [_httpFetcher setTestBlock:testBlock];
+  
+  XCTestExpectation *completionExpectation =
+      [self expectationWithDescription:@"Callback called with error"];
+  
+  [_profileDataFetcher
+      fetchProfileDataWithAuthState:authState
+                         completion:^(GIDProfileData *profileData, NSError *error) {
+    XCTAssertNil(profileData);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, kErrorDomain);
+    XCTAssertEqual(error.code, kErrorCode);
+    [completionExpectation fulfill];
+  }];
+  
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+// Fetch the NSData successfully but can not parse it.
+- (void)testFetchProfileData_fromInfoURL_parsingError {
+  OIDTokenResponse *tokenResponse =
+      [OIDTokenResponse testInstanceWithIDToken:nil
+                                    accessToken:kAccessToken
+                                      expiresIn:@(300)
+                                   refreshToken:kRefreshToken
+                                   tokenRequest:nil];
+  OIDAuthState *authState = [OIDAuthState testInstanceWithTokenResponse:tokenResponse];
+  
+  XCTestExpectation *fetcherExpectation =
+      [self expectationWithDescription:@"_httpFetcher is invoked"];
+  GIDHTTPFetcherTestBlock testBlock =
+      ^(NSURLRequest *request, GIDHTTPFetcherFakeResponseProviderBlock responseProvider) {
+        NSData *data = [[NSData alloc] init];
+        responseProvider(data, nil);
+        [fetcherExpectation fulfill];
+      };
+  [_httpFetcher setTestBlock:testBlock];
+  
+  XCTestExpectation *completionExpectation =
+      [self expectationWithDescription:@"Callback called with error"];
+  
+  [_profileDataFetcher
+      fetchProfileDataWithAuthState:authState
+                         completion:^(GIDProfileData *profileData, NSError *error) {
+    XCTAssertNil(profileData);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, NSCocoaErrorDomain);
+    [completionExpectation fulfill];
+  }];
+  
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+#pragma mark - Helpers
+
+- (NSError *)error {
+  return [NSError errorWithDomain:kErrorDomain code:kErrorCode userInfo:nil];
+}
+
+@end

--- a/GoogleSignIn/Tests/Unit/GIDProfileDataFetcherTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDProfileDataFetcherTest.m
@@ -55,7 +55,7 @@ static NSInteger const kErrorCode = 400;
   [_httpFetcher setTestBlock:testBlock];
   
   XCTestExpectation *expectation =
-      [self expectationWithDescription:@"Callback called with no error"];
+      [self expectationWithDescription:@"completion is invoked"];
   
   [_profileDataFetcher
       fetchProfileDataWithAuthState:authState
@@ -91,7 +91,7 @@ static NSInteger const kErrorCode = 400;
   [_httpFetcher setTestBlock:testBlock];
   
   XCTestExpectation *completionExpectation =
-      [self expectationWithDescription:@"Callback called with error"];
+      [self expectationWithDescription:@"completion is invoked"];
   
   [_profileDataFetcher
       fetchProfileDataWithAuthState:authState
@@ -127,7 +127,7 @@ static NSInteger const kErrorCode = 400;
   [_httpFetcher setTestBlock:testBlock];
   
   XCTestExpectation *completionExpectation =
-      [self expectationWithDescription:@"Callback called with error"];
+      [self expectationWithDescription:@"completion is invoked"];
   
   [_profileDataFetcher
       fetchProfileDataWithAuthState:authState

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -33,6 +33,8 @@
 #import "GoogleSignIn/Sources/GIDKeychainHandler/Implementations/Fakes/GIDFakeKeychainHandler.h"
 #import "GoogleSignIn/Sources/GIDHTTPFetcher/Implementations/Fakes/GIDFakeHTTPFetcher.h"
 #import "GoogleSignIn/Sources/GIDHTTPFetcher/Implementations/GIDHTTPFetcher.h"
+#import "GoogleSignIn/Sources/GIDProfileDataFetcher/Implementations/GIDProfileDataFetcher.h"
+
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import "GoogleSignIn/Sources/GIDEMMErrorHandler.h"
@@ -311,8 +313,10 @@ static NSString *const kNewScope = @"newScope";
   
   _httpFetcher = [[GIDFakeHTTPFetcher alloc] init];
   
+  id<GIDProfileDataFetcher> profileDataFetcher = [[GIDProfileDataFetcher alloc] init];
   _signIn = [[GIDSignIn alloc] initWithKeychainHandler:_keychainHandler
-                                           httpFetcher:_httpFetcher];
+                                           httpFetcher:_httpFetcher
+                                    profileDataFetcher:profileDataFetcher];
   _hint = nil;
 
   __weak GIDSignInTest *weakSelf = self;


### PR DESCRIPTION
GIDProfileDataFetcher fetches the user info. It either extracts an ID token out of the OIDAuthState object or fetches user profile data through `GIDHTTPFetcher`.

Details in this PR:
1. Add GIDProfileDataFetcher API, implementation and unit test.
2. Convert the creation of GIDProfileData in GIDSignIn.m into an initializer of GIDProfileData.

Next step:
Create a fake for GIDProfileDataFetcher and use it in GIDSignInTest.m to replace mocks.