### PR TITLE
Fix the restorePreviousSignIn when completion is nil

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -202,6 +202,9 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                                                                NSError *_Nullable error))completion {
   [self signInWithOptions:[GIDSignInInternalOptions silentOptionsWithCompletion:
                            ^(GIDSignInResult *signInResult, NSError *error) {
+    if (!completion) {
+      return;
+    }
     if (signInResult) {
       completion(signInResult.user, nil);
     } else {

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -503,6 +503,18 @@ static NSString *const kNewScope = @"newScope";
   [_authState verify];
 }
 
+- (void)testNotRestorePreviousSignWhenCompletionIsNil {
+  [[[_authorization expect] andReturn:_authState] authState];
+  [[[_authState expect] andReturnValue:[NSNumber numberWithBool:NO]] isAuthorized];
+  _completionCalled = NO;
+  _authError = nil;
+
+  [_signIn restorePreviousSignInWithCompletion:nil];
+  [NSThread sleepForTimeInterval:1.0];
+
+  XCTAssertNil(_signIn.currentUser);
+}
+
 - (void)testOAuthLogin {
   [self OAuthLoginWithAddScopesFlow:NO
                           authError:nil

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -516,24 +516,18 @@ static NSString *const kNewScope = @"newScope";
   [[[_authorization expect] andReturn:_authState] authState];
   [[[_authState expect] andReturnValue:[NSNumber numberWithBool:YES]] isAuthorized];
 
-  OIDAuthorizationResponse *authResponse =
-        [OIDAuthorizationResponse testInstanceWithAdditionalParameters:nil
-                                                           errorString:nil];
   OIDTokenResponse *tokenResponse =
-        [OIDTokenResponse testInstanceWithIDToken:[OIDTokenResponse fatIDToken]
-                                      accessToken:kAccessToken
-                                        expiresIn: nil
-                                     refreshToken:kRefreshToken
-                                     tokenRequest:nil];
+  [OIDTokenResponse testInstanceWithIDToken:[OIDTokenResponse fatIDToken]
+                                accessToken:kAccessToken
+                                  expiresIn:nil
+                               refreshToken:kRefreshToken
+                               tokenRequest:nil];
 
   [[[_authState stub] andReturn:tokenResponse] lastTokenResponse];
 
-  // SaveAuthCallback
-  __block OIDAuthState *authState;
-  __block GIDProfileData *profileData;
   [[[_user stub] andReturn:_user] alloc];
-        (void)[[[_user expect] andReturn:_user] initWithAuthState:SAVE_TO_ARG_BLOCK(authState)
-                                                      profileData:SAVE_TO_ARG_BLOCK(profileData)];
+  (void)[[[_user expect] andReturn:_user] initWithAuthState:OCMOCK_ANY
+                                                profileData:OCMOCK_ANY];
   XCTAssertNil(_signIn.currentUser);
 
   [_signIn restorePreviousSignInWithCompletion:nil];
@@ -1278,7 +1272,7 @@ static NSString *const kNewScope = @"newScope";
     [[[_authState expect] andReturn:tokenResponse] lastTokenResponse];
     if (oldAccessToken) {
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-      // Corresponds to EMM support 
+      // Corresponds to EMM support
       [[[_authState expect] andReturn:authResponse] lastAuthorizationResponse];
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
       [[[_authState expect] andReturn:tokenResponse] lastTokenResponse];

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -517,13 +517,18 @@ static NSString *const kNewScope = @"newScope";
   [[[_authState expect] andReturnValue:[NSNumber numberWithBool:YES]] isAuthorized];
 
   OIDTokenResponse *tokenResponse =
-  [OIDTokenResponse testInstanceWithIDToken:[OIDTokenResponse fatIDToken]
-                                accessToken:kAccessToken
-                                  expiresIn:nil
-                               refreshToken:kRefreshToken
-                               tokenRequest:nil];
+      [OIDTokenResponse testInstanceWithIDToken:[OIDTokenResponse fatIDToken]
+                                    accessToken:kAccessToken
+                                      expiresIn:nil
+                                   refreshToken:kRefreshToken
+                                   tokenRequest:nil];
 
   [[[_authState stub] andReturn:tokenResponse] lastTokenResponse];
+
+  id profile = OCMStrictClassMock([GIDProfileData class]);
+  OCMStub([profile email]).andReturn(kUserEmail);
+  OCMStub([_user profile]).andReturn(profile);
+  OCMStub([_user userID]).andReturn(kUserID);
 
   [[[_user stub] andReturn:_user] alloc];
   (void)[[[_user expect] andReturn:_user] initWithAuthState:OCMOCK_ANY
@@ -533,6 +538,8 @@ static NSString *const kNewScope = @"newScope";
   [_signIn restorePreviousSignInWithCompletion:nil];
 
   XCTAssertNotNil(_signIn.currentUser);
+  XCTAssertEqualObjects(_signIn.currentUser.userID, kUserID);
+  XCTAssertEqualObjects(_signIn.currentUser.profile.email, kUserEmail);
   [_authState verify];
 }
 

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -38,9 +38,6 @@
 #import "GoogleSignIn/Tests/Unit/GIDFakeFetcher.h"
 #import "GoogleSignIn/Tests/Unit/GIDFakeFetcherService.h"
 #import "GoogleSignIn/Tests/Unit/GIDFakeMainBundle.h"
-#import "GoogleSignIn/Tests/Unit/GIDGoogleUser+Testing.h"
-#import "GoogleSignIn/Tests/Unit/GIDProfileData+Testing.h"
-#import "GoogleSignIn/Tests/Unit/OIDAuthState+Testing.h"
 #import "GoogleSignIn/Tests/Unit/OIDAuthorizationResponse+Testing.h"
 #import "GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h"
 

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -38,6 +38,9 @@
 #import "GoogleSignIn/Tests/Unit/GIDFakeFetcher.h"
 #import "GoogleSignIn/Tests/Unit/GIDFakeFetcherService.h"
 #import "GoogleSignIn/Tests/Unit/GIDFakeMainBundle.h"
+#import "GoogleSignIn/Tests/Unit/GIDGoogleUser+Testing.h"
+#import "GoogleSignIn/Tests/Unit/GIDProfileData+Testing.h"
+#import "GoogleSignIn/Tests/Unit/OIDAuthState+Testing.h"
 #import "GoogleSignIn/Tests/Unit/OIDAuthorizationResponse+Testing.h"
 #import "GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h"
 
@@ -525,11 +528,7 @@ static NSString *const kNewScope = @"newScope";
 
   [[[_authState stub] andReturn:tokenResponse] lastTokenResponse];
 
-  id profile = OCMStrictClassMock([GIDProfileData class]);
-  OCMStub([profile email]).andReturn(kUserEmail);
-  OCMStub([_user profile]).andReturn(profile);
-  OCMStub([_user userID]).andReturn(kUserID);
-
+  // TODO: Create a real GIDGoogleUser to verify the signed in user value(#306).
   [[[_user stub] andReturn:_user] alloc];
   (void)[[[_user expect] andReturn:_user] initWithAuthState:OCMOCK_ANY
                                                 profileData:OCMOCK_ANY];
@@ -538,9 +537,6 @@ static NSString *const kNewScope = @"newScope";
   [_signIn restorePreviousSignInWithCompletion:nil];
 
   XCTAssertNotNil(_signIn.currentUser);
-  XCTAssertEqualObjects(_signIn.currentUser.userID, kUserID);
-  XCTAssertEqualObjects(_signIn.currentUser.profile.email, kUserEmail);
-  [_authState verify];
 }
 
 - (void)testOAuthLogin {


### PR DESCRIPTION
Return to void and not trigger the callback when the completion is nil.