### PR TITLE
Remove macos-11 runner

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12]
         podspec: [GoogleSignIn.podspec, GoogleSignInSwiftSupport.podspec]
         flag: [
           "", 
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12]
         sdk: ['macosx', 'iphonesimulator']
         include:
           - sdk: 'macosx'


### PR DESCRIPTION
The macos-11 runner [fails to launch the test runner](https://github.com/google/GoogleSignIn-iOS/actions/runs/4694725464/jobs/8323148812), and so merging is blocked since tests are failing.