### PR TITLE
Update UI automation test to use return as name for button

### DIFF
--- a/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
+++ b/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
@@ -64,7 +64,7 @@ class DaysUntilBirthdayUITests_iOS: XCTestCase {
 
 extension DaysUntilBirthdayUITests_iOS {
   /// Performs a sign in.
-  /// - returns: `true` if the sign in was succesfull.
+  /// - returns: `true` if the sign in was successful.
   func signIn() -> Bool {
     let signInButton = sampleApp.buttons["GoogleSignInButton"]
     guard signInButton.exists else {

--- a/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
+++ b/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
@@ -141,16 +141,16 @@ extension DaysUntilBirthdayUITests_iOS {
     guard sampleApp
             .keyboards
             .element
-            .buttons["go"]
+            .buttons["return"]
             .waitForExistence(timeout: timeout) else {
-      XCTFail("Failed to find 'go' button")
+      XCTFail("Failed to find 'return' button")
       return false
     }
 
     sampleApp
       .secureTextFields["Enter your password"]
       .typeText(Credential.password.rawValue)
-    sampleApp.keyboards.element.buttons["go"].tap()
+    sampleApp.keyboards.element.buttons["return"].tap()
 
     return true
   }


### PR DESCRIPTION
Previously, the UI automation test used 'go' for the button name when the keyboard was displayed during password entry, but it appears that has been changed to 'return.'