### PR TITLE
Update to Swift 5 in GoogleSignInSwiftSupport.podspec

### DIFF
--- a/GoogleSignInSwiftSupport.podspec
+++ b/GoogleSignInSwiftSupport.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'GoogleSignInSwiftSupport'
-  s.version = '7.0.0'
-  s.swift_version = '4.0'
+  s.version = '7.0.1'
+  s.swift_version = '5.0'
   s.summary = 'Adds Swift-focused support for Google Sign-In.'
   s.description = 'Additional Swift support for the Google Sign-In SDK.'
   s.homepage = 'https://developers.google.com/identity/sign-in/ios/'


### PR DESCRIPTION
This change addresses a warning from Xcode 14.3 that suggests upgrading to Swift 5.

Swift 5 is a fine version to support since it was released with Xcode 10.2, which supported development for macOS 10.14.4, and iOS 12.2. Both of these are lower than the supported versions of macOS (10.15) and iOS (13.0) listed in `GoogleSignInSwiftSupport.podspec`.

Fixes #316