### PR TITLE
Remove unnecessary parameter used in creating GACAppAttestProvider

### DIFF
--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -33,7 +33,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
   ]
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
-  s.dependency 'AppCheckCore', '~> 0.1.0-alpha'
+  s.dependency 'AppCheckCore', '~> 0.1.0-alpha.4'
   s.dependency 'AppAuth', '~> 1.6'
   s.dependency 'GTMAppAuth', '~> 4.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 1.1', '< 4.0'

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.m
@@ -38,8 +38,15 @@ NSUInteger const kGIDAppCheckProviderFakeError = 1;
   return self;
 }
 
-- (void)getTokenWithCompletion:(nonnull void (^)(GACAppCheckToken * _Nullable,
+- (void)getTokenWithCompletion:(nonnull void (^)(id<GACAppCheckTokenProtocol> _Nullable,
                                                  NSError * _Nullable))handler {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    handler(self.token, self.error);
+  });
+}
+
+- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+                                                   NSError * _Nullable))handler {
   dispatch_async(dispatch_get_main_queue(), ^{
     handler(self.token, self.error);
   });

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -162,7 +162,6 @@ typedef void (^GIDAppCheckTokenCompletion)(id<GACAppCheckTokenProtocol> _Nullabl
                                                    baseURL:kGIDAppAttestBaseURL
                                                     APIKey:nil
                                        keychainAccessGroup:nil
-                                                limitedUse:YES
                                               requestHooks:nil];
 }
 

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -110,8 +110,8 @@ typedef void (^GIDAppCheckTokenCompletion)(id<GACAppCheckTokenProtocol> _Nullabl
       return;
     }
 
-    [self.appCheck getLimitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                      NSError * _Nullable error) {
+    [self.appCheck limitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
+                                                   NSError * _Nullable error) {
       NSError * __block maybeError = error;
       @synchronized (self) {
         if (!token && !error) {
@@ -139,8 +139,8 @@ typedef void (^GIDAppCheckTokenCompletion)(id<GACAppCheckTokenProtocol> _Nullabl
 
 - (void)getLimitedUseTokenWithCompletion:(nullable GIDAppCheckTokenCompletion)completion {
   dispatch_async(self.workerQueue, ^{
-    [self.appCheck getLimitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                      NSError * _Nullable error) {
+    [self.appCheck limitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
+                                                   NSError * _Nullable error) {
       if (token) {
         [self.userDefaults setBool:YES forKey:kGIDAppCheckPreparedKey];
       }


### PR DESCRIPTION
Changes are per updates in app-check dependency ([1](https://github.com/google/app-check/pull/11#issuecomment-1688349714) and [2](https://github.com/google/app-check/pull/14)).