### PR TITLE
Support using a debug app check provider during configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Podfile.lock
 
 # Firebase App Check Example
 **/GoogleService-Info.plist
+**/AppCheckSecrets.xcconfig

--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -33,7 +33,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
   ]
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
-  s.dependency 'AppCheckCore', '~> 0.1.0-alpha.4'
+  s.dependency 'AppCheckCore', '~> 0.1.0-alpha.6'
   s.dependency 'AppAuth', '~> 1.6'
   s.dependency 'GTMAppAuth', '~> 4.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 1.1', '< 4.0'

--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -33,7 +33,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
   ]
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
-  s.dependency 'AppCheckCore', '~> 0.1.0-alpha.8'
+  s.dependency 'AppCheckCore', '~> 0.1.0-alpha.9'
   s.dependency 'AppAuth', '~> 1.6'
   s.dependency 'GTMAppAuth', '~> 4.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 1.1', '< 4.0'

--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -33,7 +33,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
   ]
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
-  s.dependency 'AppCheckCore', '~> 0.1.0-alpha.6'
+  s.dependency 'AppCheckCore', '~> 0.1.0-alpha.8'
   s.dependency 'AppAuth', '~> 1.6'
   s.dependency 'GTMAppAuth', '~> 4.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 1.1', '< 4.0'

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.h
@@ -31,7 +31,7 @@ NS_CLASS_AVAILABLE_IOS(14)
 /// error.
 ///
 /// @param token The `GACAppCheckToken` instance to pass into the completion called from
-///     `getTokenWithCompletion:`. Use `nullable` if you would like a placeholder token from
+///     `getTokenWithCompletion:`. Use `nil` if you would like a placeholder token from
 ///     AppCheckCore.
 /// @param error The `NSError` to pass into the completion called from
 ///     `getTokenWithCompletion:`.

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.h
@@ -31,7 +31,8 @@ NS_CLASS_AVAILABLE_IOS(14)
 /// error.
 ///
 /// @param token The `GACAppCheckToken` instance to pass into the completion called from
-///     `getTokenWithCompletion:`.
+///     `getTokenWithCompletion:`. Use `nullable` if you would like a placeholder token from
+///     AppCheckCore.
 /// @param error The `NSError` to pass into the completion called from
 ///     `getTokenWithCompletion:`.
 - (instancetype)initWithAppCheckToken:(nullable GACAppCheckToken *)token

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.m
@@ -22,14 +22,14 @@ NSUInteger const kGIDAppCheckProviderFakeError = 1;
 
 @interface GIDAppCheckProviderFake ()
 
-@property(nonatomic, strong, nullable) id<GACAppCheckTokenProtocol> token;
+@property(nonatomic, strong, nullable) GACAppCheckToken *token;
 @property(nonatomic, strong, nullable) NSError *error;
 
 @end
 
 @implementation GIDAppCheckProviderFake
 
-- (instancetype)initWithAppCheckToken:(nullable id<GACAppCheckTokenProtocol>)token
+- (instancetype)initWithAppCheckToken:(nullable GACAppCheckToken *)token
                                 error:(nullable NSError *)error {
   if (self = [super init]) {
     _token = token;
@@ -38,14 +38,14 @@ NSUInteger const kGIDAppCheckProviderFakeError = 1;
   return self;
 }
 
-- (void)getTokenWithCompletion:(nonnull void (^)(id<GACAppCheckTokenProtocol> _Nullable,
-                                                 NSError * _Nullable))handler {
+- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken * _Nullable,
+                                         NSError * _Nullable))handler {
   dispatch_async(dispatch_get_main_queue(), ^{
     handler(self.token, self.error);
   });
 }
 
-- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken * _Nullable,
                                                    NSError * _Nullable))handler {
   dispatch_async(dispatch_get_main_queue(), ^{
     handler(self.token, self.error);

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.m
@@ -38,14 +38,13 @@ NSUInteger const kGIDAppCheckProviderFakeError = 1;
   return self;
 }
 
-- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken * _Nullable,
-                                         NSError * _Nullable))handler {
+- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken *, NSError * _Nullable))handler {
   dispatch_async(dispatch_get_main_queue(), ^{
     handler(self.token, self.error);
   });
 }
 
-- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken * _Nullable,
+- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *,
                                                    NSError * _Nullable))handler {
   dispatch_async(dispatch_get_main_queue(), ^{
     handler(self.token, self.error);

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
@@ -32,12 +32,15 @@ NS_CLASS_AVAILABLE_IOS(14)
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/// Creates the instance of this App Check wrapper class.
+/// Creates the instance of this App Check wrapper class using `GACAppCheckDebugProvider`.
 ///
 /// The instance is created using `+[NSUserDefaults standardUserDefaults]`.
++ (instancetype)appCheckUsingDebugProvider;
+
+/// Creates the instance of this App Check wrapper class using `GACAppAttestProvider`.
 ///
-/// @param useDebugProvider Whether or not the debug App Check provider should be used.
-- (instancetype)initWithDebugProvider:(BOOL)useDebugProvider;
+/// The instance is created using `+[NSUserDefaults standardUserDefaults]`.
++ (instancetype)appCheckUsingAppAttestProvider;
 
 /// Creates the instance of this App Check wrapper class.
 ///

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
@@ -61,11 +61,9 @@ NS_CLASS_AVAILABLE_IOS(14)
 
 /// Fetches the limited use Firebase token.
 ///
-/// @param completion A `nullable` callback with the `FIRAppCheckToken` if present, or an `NSError`
-///     otherwise.
+/// @param completion A `nullable` callback with the `FIRAppCheckToken`, or an `NSError` otherwise.
 - (void)getLimitedUseTokenWithCompletion:
-    (nullable void (^)(GACAppCheckToken * _Nullable token,
-                       NSError * _Nullable error))completion;
+    (nullable void (^)(GACAppCheckToken *token, NSError * _Nullable error))completion;
 
 /// Whether or not the App Attest key ID created and the attestation object has been fetched.
 - (BOOL)isPrepared;

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
@@ -34,8 +34,10 @@ NS_CLASS_AVAILABLE_IOS(14)
 
 /// Creates the instance of this App Check wrapper class using `GACAppCheckDebugProvider`.
 ///
+/// @param APIKey The API Key to use when creating the debug App Check provider.
+///
 /// The instance is created using `+[NSUserDefaults standardUserDefaults]`.
-+ (instancetype)appCheckUsingDebugProvider;
++ (instancetype)appCheckUsingDebugProviderWithAPIKey:(NSString *)APIKey;
 
 /// Creates the instance of this App Check wrapper class using `GACAppAttestProvider`.
 ///

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
@@ -23,7 +23,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol GACAppCheckProvider;
-@protocol GACAppCheckTokenProtocol;
+@class GACAppCheckToken;
 
 extern NSString *const kGIDAppCheckPreparedKey;
 
@@ -58,7 +58,7 @@ NS_CLASS_AVAILABLE_IOS(14)
 /// @param completion A `nullable` callback with the `FIRAppCheckToken` if present, or an `NSError`
 ///     otherwise.
 - (void)getLimitedUseTokenWithCompletion:
-    (nullable void (^)(id<GACAppCheckTokenProtocol> _Nullable token,
+    (nullable void (^)(GACAppCheckToken * _Nullable token,
                        NSError * _Nullable error))completion;
 
 /// Whether or not the App Attest key ID created and the attestation object has been fetched.

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
@@ -30,13 +30,14 @@ extern NSString *const kGIDAppCheckPreparedKey;
 NS_CLASS_AVAILABLE_IOS(14)
 @interface GIDAppCheck : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Creates the instance of this App Check wrapper class.
 ///
-/// The instance is created using `+[NSUserDefaults standardUserDefaults]` and the standard App
-/// Check provider.
+/// The instance is created using `+[NSUserDefaults standardUserDefaults]`.
 ///
-/// @SeeAlso The App Check provider is constructed with `+[GIDAppCheck standardAppCheckProvider]`.
-- (instancetype)init;
+/// @param useDebugProvider Whether or not the debug App Check provider should be used.
+- (instancetype)initWithDebugProvider:(BOOL)useDebugProvider;
 
 /// Creates the instance of this App Check wrapper class.
 ///

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -51,8 +51,8 @@ typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken * _Nullable,
 
 @implementation GIDAppCheck
 
-+ (instancetype)appCheckUsingDebugProvider {
-  return [[self alloc] initWithAppCheckProvider:[GIDAppCheck debugAppCheckProvider]
++ (instancetype)appCheckUsingDebugProviderWithAPIKey:(NSString *)APIKey {
+  return [[self alloc] initWithAppCheckProvider:[GIDAppCheck debugAppCheckProviderWithAPIKey:APIKey]
                                    userDefaults:[NSUserDefaults standardUserDefaults]];
 }
 
@@ -168,10 +168,11 @@ typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken * _Nullable,
                                               requestHooks:nil];
 }
 
-+ (id<GACAppCheckProvider>)debugAppCheckProvider {
++ (id<GACAppCheckProvider>)debugAppCheckProviderWithAPIKey:(NSString *)APIKey {
   return [[GACAppCheckDebugProvider alloc] initWithServiceName:kGIDAppAttestServiceName
                                                   resourceName:[GIDAppCheck appAttestResourceName]
-                                                        APIKey:nil
+                                                       baseURL:kGIDAppAttestBaseURL
+                                                        APIKey:APIKey
                                                   requestHooks:nil];
 }
 

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -22,6 +22,7 @@
 #import <AppCheckCore/GACAppCheckSettings.h>
 #import <AppCheckCore/GACAppCheckTokenResult.h>
 #import <AppCheckCore/GACAppAttestProvider.h>
+#import <AppCheckCore/GACAppCheckDebugProvider.h>
 
 #import "GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h"
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDAppCheckError.h"

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -36,8 +36,7 @@ static NSString *const kGIDAppAttestResourceNameFormat = @"oauthClients/%@";
 static NSString *const kGIDAppAttestBaseURL = @"https://firebaseappcheck.googleapis.com/v1beta";
 
 typedef void (^GIDAppCheckPrepareCompletion)(NSError * _Nullable);
-typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken * _Nullable,
-                                           NSError * _Nullable);
+typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken *,NSError * _Nullable);
 
 @interface GIDAppCheck ()
 

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -50,8 +50,13 @@ typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken * _Nullable,
 
 @implementation GIDAppCheck
 
-- (instancetype)init {
-  id<GACAppCheckProvider> provider = [GIDAppCheck standardAppCheckProvider];
+- (instancetype)initWithDebugProvider:(BOOL)useDebugProvider {
+  id<GACAppCheckProvider> provider = nil;
+  if (useDebugProvider) {
+    provider = [GIDAppCheck standardAppCheckProvider];
+  } else {
+    provider = [GIDAppCheck debugAppCheckProvider];
+  }
   NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
   return [self initWithAppCheckProvider:provider userDefaults:userDefaults];
 }
@@ -161,6 +166,13 @@ typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken * _Nullable,
                                                     APIKey:nil
                                        keychainAccessGroup:nil
                                               requestHooks:nil];
+}
+
++ (id<GACAppCheckProvider>)debugAppCheckProvider {
+  return [[GACAppCheckDebugProvider alloc] initWithServiceName:kGIDAppAttestServiceName
+                                                  resourceName:[GIDAppCheck appAttestResourceName]
+                                                        APIKey:nil
+                                                  requestHooks:nil];
 }
 
 @end

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -51,15 +51,14 @@ typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken * _Nullable,
 
 @implementation GIDAppCheck
 
-- (instancetype)initWithDebugProvider:(BOOL)useDebugProvider {
-  id<GACAppCheckProvider> provider = nil;
-  if (useDebugProvider) {
-    provider = [GIDAppCheck standardAppCheckProvider];
-  } else {
-    provider = [GIDAppCheck debugAppCheckProvider];
-  }
-  NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-  return [self initWithAppCheckProvider:provider userDefaults:userDefaults];
++ (instancetype)appCheckUsingDebugProvider {
+  return [[self alloc] initWithAppCheckProvider:[GIDAppCheck debugAppCheckProvider]
+                                   userDefaults:[NSUserDefaults standardUserDefaults]];
+}
+
++ (instancetype)appCheckUsingAppAttestProvider {
+  return [[self alloc] initWithAppCheckProvider:[GIDAppCheck appAttestProvider]
+                                   userDefaults:[NSUserDefaults standardUserDefaults]];
 }
 
 - (instancetype)initWithAppCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
@@ -160,7 +159,7 @@ typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken * _Nullable,
   return [NSString stringWithFormat:kGIDAppAttestResourceNameFormat, clientID];
 }
 
-+ (id<GACAppCheckProvider>)standardAppCheckProvider {
++ (id<GACAppCheckProvider>)appAttestProvider {
   return [[GACAppAttestProvider alloc] initWithServiceName:kGIDAppAttestServiceName
                                               resourceName:[GIDAppCheck appAttestResourceName]
                                                    baseURL:kGIDAppAttestBaseURL

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -20,7 +20,7 @@
 
 #import <AppCheckCore/GACAppCheck.h>
 #import <AppCheckCore/GACAppCheckSettings.h>
-#import <AppCheckCore/GACAppCheckToken.h>
+#import <AppCheckCore/GACAppCheckTokenResult.h>
 #import <AppCheckCore/GACAppAttestProvider.h>
 
 #import "GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h"
@@ -35,7 +35,7 @@ static NSString *const kGIDAppAttestResourceNameFormat = @"oauthClients/%@";
 static NSString *const kGIDAppAttestBaseURL = @"https://firebaseappcheck.googleapis.com/v1beta";
 
 typedef void (^GIDAppCheckPrepareCompletion)(NSError * _Nullable);
-typedef void (^GIDAppCheckTokenCompletion)(id<GACAppCheckTokenProtocol> _Nullable,
+typedef void (^GIDAppCheckTokenCompletion)(GACAppCheckToken * _Nullable,
                                            NSError * _Nullable);
 
 @interface GIDAppCheck ()
@@ -110,17 +110,16 @@ typedef void (^GIDAppCheckTokenCompletion)(id<GACAppCheckTokenProtocol> _Nullabl
       return;
     }
 
-    [self.appCheck limitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                   NSError * _Nullable error) {
-      NSError * __block maybeError = error;
+    [self.appCheck limitedUseTokenWithCompletion:^(GACAppCheckTokenResult * _Nonnull result) {
+      NSError * __block maybeError = result.error;
       @synchronized (self) {
-        if (!token && !error) {
+        if (!result.token && !result.error) {
           maybeError = [NSError errorWithDomain:kGIDAppCheckErrorDomain
                                            code:kGIDAppCheckUnexpectedError
                                        userInfo:nil];
         }
 
-        if (token) {
+        if (result.token) {
           [self.userDefaults setBool:YES forKey:kGIDAppCheckPreparedKey];
         }
 
@@ -139,13 +138,12 @@ typedef void (^GIDAppCheckTokenCompletion)(id<GACAppCheckTokenProtocol> _Nullabl
 
 - (void)getLimitedUseTokenWithCompletion:(nullable GIDAppCheckTokenCompletion)completion {
   dispatch_async(self.workerQueue, ^{
-    [self.appCheck limitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                   NSError * _Nullable error) {
-      if (token) {
+    [self.appCheck limitedUseTokenWithCompletion:^(GACAppCheckTokenResult * _Nonnull result) {
+      if (result.token) {
         [self.userDefaults setBool:YES forKey:kGIDAppCheckPreparedKey];
       }
       if (completion) {
-        completion(token, error);
+        completion(result.token, result.error);
       }
     }];
   });

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -479,8 +479,8 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 #pragma mark - Configuring and pre-warming
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-- (void)configureWithDebugProvider:(BOOL)useDebugProvider
-                        completion:(nullable void (^)(NSError * _Nullable))completion {
+- (void)configureWithDebugProviderEnabled:(BOOL)useDebugProvider
+                               completion:(nullable void (^)(NSError * _Nullable))completion {
   @synchronized(self) {
     if (useDebugProvider) {
       _appCheck = [GIDAppCheck appCheckUsingDebugProvider];

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -479,12 +479,20 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 #pragma mark - Configuring and pre-warming
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-- (void)configureWithDebugProviderEnabled:(BOOL)useDebugProvider
-                               completion:(nullable void (^)(NSError * _Nullable))completion {
+- (void)configureWithCompletion:(nullable void (^)(NSError * _Nullable))completion {
   @synchronized(self) {
-    if (useDebugProvider) {
-      _appCheck = [GIDAppCheck appCheckUsingDebugProvider];
-    }
+    [_appCheck prepareForAppCheckWithCompletion:^(NSError * _Nullable error) {
+      if (completion) {
+        completion(error);
+      }
+    }];
+  }
+}
+
+- (void)configureDebugProviderWithAPIKey:(NSString *)APIKey
+                              completion:(nullable void (^)(NSError * _Nullable))completion {
+  @synchronized(self) {
+    _appCheck = [GIDAppCheck appCheckUsingDebugProviderWithAPIKey:APIKey];
     [_appCheck prepareForAppCheckWithCompletion:^(NSError * _Nullable error) {
       if (completion) {
         completion(error);

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -464,7 +464,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
         [[GTMKeychainStore alloc] initWithItemName:kGTMAppAuthKeychainName];
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     if (@available(iOS 14.0, *)) {
-      GIDAppCheck *appCheck = [[GIDAppCheck alloc] initWithDebugProvider:NO];
+      GIDAppCheck *appCheck = [GIDAppCheck appCheckUsingAppAttestProvider];
       sharedInstance = [[self alloc] initWithKeychainStore:keychainStore
                                                   appCheck:appCheck];
     }
@@ -483,7 +483,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                         completion:(nullable void (^)(NSError * _Nullable))completion {
   @synchronized(self) {
     if (useDebugProvider) {
-      _appCheck = [[GIDAppCheck alloc] initWithDebugProvider:useDebugProvider];
+      _appCheck = [GIDAppCheck appCheckUsingDebugProvider];
     }
     [_appCheck prepareForAppCheckWithCompletion:^(NSError * _Nullable error) {
       if (completion) {

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -646,8 +646,8 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
         _timedLoader = [[GIDTimedLoader alloc] initWithPresentingViewController:presentingVC];
       }
       [_timedLoader startTiming];
-      [self->_appCheck getLimitedUseTokenWithCompletion:
-          ^(id<GACAppCheckTokenProtocol> _Nullable token, NSError * _Nullable error) {
+      [self->_appCheck getLimitedUseTokenWithCompletion:^(GACAppCheckToken * _Nullable token,
+                                                          NSError * _Nullable error) {
         OIDAuthorizationRequest *request = nil;
         if (token) {
           additionalParameters[kClientAssertionTypeParameter] = kClientAssertionTypeParameterValue;

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -464,7 +464,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
         [[GTMKeychainStore alloc] initWithItemName:kGTMAppAuthKeychainName];
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     if (@available(iOS 14.0, *)) {
-      GIDAppCheck *appCheck = [[GIDAppCheck alloc] init];
+      GIDAppCheck *appCheck = [[GIDAppCheck alloc] initWithDebugProvider:NO];
       sharedInstance = [[self alloc] initWithKeychainStore:keychainStore
                                                   appCheck:appCheck];
     }
@@ -479,8 +479,12 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 #pragma mark - Configuring and pre-warming
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-- (void)configureWithCompletion:(nullable void (^)(NSError * _Nullable))completion {
+- (void)configureWithDebugProvider:(BOOL)useDebugProvider
+                        completion:(nullable void (^)(NSError * _Nullable))completion {
   @synchronized(self) {
+    if (useDebugProvider) {
+      _appCheck = [[GIDAppCheck alloc] initWithDebugProvider:useDebugProvider];
+    }
     [_appCheck prepareForAppCheckWithCompletion:^(NSError * _Nullable error) {
       if (completion) {
         completion(error);

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -80,7 +80,7 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 - (void)configureWithDebugProviderEnabled:(BOOL)useDebugProvider
                                completion:(nullable void (^)(NSError * _Nullable error))completion
 API_AVAILABLE(ios(14))
-NS_SWIFT_NAME(configure(usingDebugProvider:completion:));
+NS_SWIFT_NAME(configure(debugProviderEnabled:completion:));
 
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -70,7 +70,6 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 
 /// Configures `GIDSignIn` for use.
 ///
-/// @param useDebugProvider Whether or not App Check should use the debug provider.
 /// @param completion A nullable callback block passing back any error arising from the
 ///     configuration process if any exists.
 ///

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -70,17 +70,28 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 
 /// Configures `GIDSignIn` for use.
 ///
-/// @param useDebugProvider Whether or not App Check should use the debug provider.
 /// @param completion A nullable callback block passing back any error arising from the
 ///     configuration process if any exists.
 ///
 /// Call this method on `GIDSignIn` prior to use and as early as possible. This method generates App
 /// Attest key IDs and the attestation object eagerly to minimize latency later on during the sign
 /// in or add scopes flows.
-- (void)configureWithDebugProviderEnabled:(BOOL)useDebugProvider
-                               completion:(nullable void (^)(NSError * _Nullable error))completion
+- (void)configureWithCompletion:(nullable void (^)(NSError * _Nullable error))completion
+NS_SWIFT_NAME(configure(completion:));
+
+/// Configures `GIDSignIn` for use.
+///
+/// @param APIKey The API Key to use during configuration of the App Check debug provider.
+/// @param completion A nullable callback block passing back any error arising from the
+///     configuration process if any exists.
+///
+/// Call this method on `GIDSignIn` prior to use and as early as possible. This method generates App
+/// Attest key IDs and the attestation object eagerly to minimize latency later on during the sign
+/// in or add scopes flows.
+- (void)configureDebugProviderWithAPIKey:(NSString *)APIKey
+                              completion:(nullable void (^)(NSError * _Nullable error))completion
 API_AVAILABLE(ios(14))
-NS_SWIFT_NAME(configure(debugProviderEnabled:completion:));
+NS_SWIFT_NAME(configureDebugProvider(withAPIKey:completion:));
 
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -77,8 +77,8 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 /// Call this method on `GIDSignIn` prior to use and as early as possible. This method generates App
 /// Attest key IDs and the attestation object eagerly to minimize latency later on during the sign
 /// in or add scopes flows.
-- (void)configureWithDebugProvider:(BOOL)useDebugProvider
-                        completion:(nullable void (^)(NSError * _Nullable error))completion
+- (void)configureWithDebugProviderEnabled:(BOOL)useDebugProvider
+                               completion:(nullable void (^)(NSError * _Nullable error))completion
 API_AVAILABLE(ios(14))
 NS_SWIFT_NAME(configure(usingDebugProvider:completion:));
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -79,7 +79,7 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 - (void)configureWithCompletion:(nullable void (^)(NSError * _Nullable error))completion
 NS_SWIFT_NAME(configure(completion:));
 
-/// Configures `GIDSignIn` for use.
+/// Configures `GIDSignIn` for use in debug or test environments.
 ///
 /// @param APIKey The API Key to use during configuration of the App Check debug provider.
 /// @param completion A nullable callback block passing back any error arising from the

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -70,15 +70,17 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 
 /// Configures `GIDSignIn` for use.
 ///
+/// @param useDebugProvider Whether or not App Check should use the debug provider.
 /// @param completion A nullable callback block passing back any error arising from the
-/// configuration process if any exists.
+///     configuration process if any exists.
 ///
 /// Call this method on `GIDSignIn` prior to use and as early as possible. This method generates App
 /// Attest key IDs and the attestation object eagerly to minimize latency later on during the sign
 /// in or add scopes flows.
-- (void)configureWithCompletion:(nullable void (^)(NSError * _Nullable error))completion
+- (void)configureWithDebugProvider:(BOOL)useDebugProvider
+                        completion:(nullable void (^)(NSError * _Nullable error))completion
 API_AVAILABLE(ios(14))
-NS_SWIFT_NAME(configureWithCompletion(completion:));
+NS_SWIFT_NAME(configure(usingDebugProvider:completion:));
 
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 

--- a/GoogleSignIn/Tests/Unit/GIDAppCheckTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDAppCheckTest.m
@@ -45,7 +45,7 @@ NS_CLASS_AVAILABLE_IOS(14)
   [self.userDefaults removeSuiteNamed:kUserDefaultsTestSuiteName];
 }
 
-- (void)testGetLimitedUseTokenFailure {
+- (void)testGetLimitedUseTokenFailureReturnsPlaceholder {
   XCTestExpectation *tokenFailExpectation =
       [self expectationWithDescription:@"App check token fail"];
   NSError *expectedError = [NSError errorWithDomain:kGIDAppCheckErrorDomain
@@ -57,9 +57,9 @@ NS_CLASS_AVAILABLE_IOS(14)
   GIDAppCheck *appCheck = [[GIDAppCheck alloc] initWithAppCheckProvider:fakeProvider
                                                            userDefaults:self.userDefaults];
 
-  [appCheck getLimitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
+  [appCheck getLimitedUseTokenWithCompletion:^(GACAppCheckToken * _Nullable token,
                                                NSError * _Nullable error) {
-    XCTAssertNil(token);
+    XCTAssertNotNil(token); // If there is an error, we expect a placeholder token
     XCTAssertEqualObjects(expectedError, error);
     [tokenFailExpectation fulfill];
   }];
@@ -126,7 +126,7 @@ NS_CLASS_AVAILABLE_IOS(14)
   XCTestExpectation *getLimitedUseTokenSucceedsExpectation =
       [self expectationWithDescription:@"getLimitedUseToken should succeed"];
 
-  [appCheck getLimitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
+  [appCheck getLimitedUseTokenWithCompletion:^(GACAppCheckToken * _Nullable token,
                                                NSError * _Nullable error) {
     XCTAssertNil(error);
     XCTAssertNotNil(token);

--- a/GoogleSignIn/Tests/Unit/GIDAppCheckTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDAppCheckTest.m
@@ -57,10 +57,10 @@ NS_CLASS_AVAILABLE_IOS(14)
   GIDAppCheck *appCheck = [[GIDAppCheck alloc] initWithAppCheckProvider:fakeProvider
                                                            userDefaults:self.userDefaults];
 
-  [appCheck getLimitedUseTokenWithCompletion:^(GACAppCheckToken * _Nullable token,
+  [appCheck getLimitedUseTokenWithCompletion:^(GACAppCheckToken *token,
                                                NSError * _Nullable error) {
-    XCTAssertNotNil(token); // If there is an error, we expect a placeholder token
     XCTAssertEqualObjects(expectedError, error);
+    XCTAssertNotNil(token); // If there is an error, we expect a placeholder token
     [tokenFailExpectation fulfill];
   }];
 
@@ -126,7 +126,7 @@ NS_CLASS_AVAILABLE_IOS(14)
   XCTestExpectation *getLimitedUseTokenSucceedsExpectation =
       [self expectationWithDescription:@"getLimitedUseToken should succeed"];
 
-  [appCheck getLimitedUseTokenWithCompletion:^(GACAppCheckToken * _Nullable token,
+  [appCheck getLimitedUseTokenWithCompletion:^(GACAppCheckToken *token,
                                                NSError * _Nullable error) {
     XCTAssertNil(error);
     XCTAssertNotNil(token);

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -398,7 +398,8 @@ static NSString *const kNewScope = @"newScope";
 
     GIDSignIn *signIn = [[GIDSignIn alloc] initWithKeychainStore:_keychainStore
                                                         appCheck:appCheck];
-    [signIn configureWithCompletion:^(NSError * _Nullable error) {
+    // Pass `NO` so that a debug provider is not created and used instead of `appCheck` above.
+    [signIn configureWithDebugProvider:NO completion:^(NSError * _Nullable error) {
       XCTAssertNil(error);
       [configureSucceedsExpecation fulfill];
     }];
@@ -422,8 +423,9 @@ static NSString *const kNewScope = @"newScope";
     GIDSignIn *signIn = [[GIDSignIn alloc] initWithKeychainStore:_keychainStore
                                                         appCheck:appCheck];
 
-    // `configureWithCompletion:` should fail if neither a token or error is present
-    [signIn configureWithCompletion:^(NSError * _Nullable error) {
+    // `configureWithWithDebugProvider:completion:` should fail if missing both token and erro
+    // Pass `NO` so that a debug provider is not created and used instead of `appCheck` above.
+    [signIn configureWithDebugProvider:NO completion:^(NSError * _Nullable error) {
       XCTAssertNotNil(error);
       XCTAssertEqual(error.code, kGIDAppCheckUnexpectedError);
       [configureFailsExpecation fulfill];

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -398,8 +398,7 @@ static NSString *const kNewScope = @"newScope";
 
     GIDSignIn *signIn = [[GIDSignIn alloc] initWithKeychainStore:_keychainStore
                                                         appCheck:appCheck];
-    // Pass `NO` so that a debug provider is not created and used instead of `appCheck` above.
-    [signIn configureWithDebugProviderEnabled:NO completion:^(NSError * _Nullable error) {
+    [signIn configureWithCompletion:^(NSError * _Nullable error) {
       XCTAssertNil(error);
       [configureSucceedsExpecation fulfill];
     }];
@@ -423,14 +422,8 @@ static NSString *const kNewScope = @"newScope";
     GIDSignIn *signIn = [[GIDSignIn alloc] initWithKeychainStore:_keychainStore
                                                         appCheck:appCheck];
 
-<<<<<<< HEAD
     // Should fail if missing both token and error
     [signIn configureWithCompletion:^(NSError * _Nullable error) {
-=======
-    // `configureWithWithDebugProvider:completion:` should fail if missing both token and erro
-    // Pass `NO` so that a debug provider is not created and used instead of `appCheck` above.
-    [signIn configureWithDebugProviderEnabled:NO completion:^(NSError * _Nullable error) {
->>>>>>> f25ca3f8211996119af8a5bd9cd1612664d69fa0
       XCTAssertNotNil(error);
       XCTAssertEqual(error.code, kGIDAppCheckUnexpectedError);
       [configureFailsExpecation fulfill];

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -398,8 +398,7 @@ static NSString *const kNewScope = @"newScope";
 
     GIDSignIn *signIn = [[GIDSignIn alloc] initWithKeychainStore:_keychainStore
                                                         appCheck:appCheck];
-    // Pass `NO` so that a debug provider is not created and used instead of `appCheck` above.
-    [signIn configureWithDebugProviderEnabled:NO completion:^(NSError * _Nullable error) {
+    [signIn configureWithCompletion:^(NSError * _Nullable error) {
       XCTAssertNil(error);
       [configureSucceedsExpecation fulfill];
     }];
@@ -423,9 +422,8 @@ static NSString *const kNewScope = @"newScope";
     GIDSignIn *signIn = [[GIDSignIn alloc] initWithKeychainStore:_keychainStore
                                                         appCheck:appCheck];
 
-    // `configureWithWithDebugProvider:completion:` should fail if missing both token and erro
-    // Pass `NO` so that a debug provider is not created and used instead of `appCheck` above.
-    [signIn configureWithDebugProviderEnabled:NO completion:^(NSError * _Nullable error) {
+    // Should fail if missing both token and error
+    [signIn configureWithCompletion:^(NSError * _Nullable error) {
       XCTAssertNotNil(error);
       XCTAssertEqual(error.code, kGIDAppCheckUnexpectedError);
       [configureFailsExpecation fulfill];

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -399,7 +399,7 @@ static NSString *const kNewScope = @"newScope";
     GIDSignIn *signIn = [[GIDSignIn alloc] initWithKeychainStore:_keychainStore
                                                         appCheck:appCheck];
     // Pass `NO` so that a debug provider is not created and used instead of `appCheck` above.
-    [signIn configureWithDebugProvider:NO completion:^(NSError * _Nullable error) {
+    [signIn configureWithDebugProviderEnabled:NO completion:^(NSError * _Nullable error) {
       XCTAssertNil(error);
       [configureSucceedsExpecation fulfill];
     }];
@@ -425,7 +425,7 @@ static NSString *const kNewScope = @"newScope";
 
     // `configureWithWithDebugProvider:completion:` should fail if missing both token and erro
     // Pass `NO` so that a debug provider is not created and used instead of `appCheck` above.
-    [signIn configureWithDebugProvider:NO completion:^(NSError * _Nullable error) {
+    [signIn configureWithDebugProviderEnabled:NO completion:^(NSError * _Nullable error) {
       XCTAssertNotNil(error);
       XCTAssertEqual(error.code, kGIDAppCheckUnexpectedError);
       [configureFailsExpecation fulfill];

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     .package(
       name: "AppCheck",
       url: "https://github.com/google/app-check.git",
-      .branch("main")),
+      .branch("CocoaPods-0.1.0-alpha.6")),
     .package(
       name: "GTMAppAuth",
       url: "https://github.com/google/GTMAppAuth.git",

--- a/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/project.pbxproj
+++ b/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 /* Begin PBXFileReference section */
 		1C96B5B2B34E31F1A1CEE95E /* Pods-AppAttestExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppAttestExample.release.xcconfig"; path = "Target Support Files/Pods-AppAttestExample/Pods-AppAttestExample.release.xcconfig"; sourceTree = "<group>"; };
 		73443A232A55F56900A4932E /* AppAttestExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AppAttestExample.entitlements; sourceTree = "<group>"; };
+		738B4A302AA7EB840056885D /* AppCheckSecrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppCheckSecrets.xcconfig; sourceTree = "<group>"; };
 		738D5F722A26BC3B00A7F11B /* BirthdayLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthdayLoader.swift; sourceTree = "<group>"; };
 		73A065612A786D10007BC7FC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		73A464002A1C3B3400BA8528 /* AppAttestExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppAttestExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -73,6 +74,7 @@
 				73A464032A1C3B3400BA8528 /* AppAttestExampleApp.swift */,
 				73A464052A1C3B3400BA8528 /* ContentView.swift */,
 				738D5F722A26BC3B00A7F11B /* BirthdayLoader.swift */,
+				738B4A302AA7EB840056885D /* AppCheckSecrets.xcconfig */,
 				73A065612A786D10007BC7FC /* Info.plist */,
 				73A464092A1C3B3500BA8528 /* Preview Content */,
 			);
@@ -219,6 +221,7 @@
 /* Begin XCBuildConfiguration section */
 		73A4640C2A1C3B3500BA8528 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 738B4A302AA7EB840056885D /* AppCheckSecrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/project.pbxproj
+++ b/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4D8DB53AAE2F7D0055DCEA7F /* Pods_AppAttestExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91F3A930BB86D9E0648046BC /* Pods_AppAttestExample.framework */; };
+		738B4A322AA8FE800056885D /* AppCheckSecretReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738B4A312AA8FE800056885D /* AppCheckSecretReader.swift */; };
 		738D5F732A26BC3B00A7F11B /* BirthdayLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738D5F722A26BC3B00A7F11B /* BirthdayLoader.swift */; };
 		73A464042A1C3B3400BA8528 /* AppAttestExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A464032A1C3B3400BA8528 /* AppAttestExampleApp.swift */; };
 		73A464062A1C3B3400BA8528 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A464052A1C3B3400BA8528 /* ContentView.swift */; };
@@ -18,6 +19,7 @@
 		1C96B5B2B34E31F1A1CEE95E /* Pods-AppAttestExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppAttestExample.release.xcconfig"; path = "Target Support Files/Pods-AppAttestExample/Pods-AppAttestExample.release.xcconfig"; sourceTree = "<group>"; };
 		73443A232A55F56900A4932E /* AppAttestExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AppAttestExample.entitlements; sourceTree = "<group>"; };
 		738B4A302AA7EB840056885D /* AppCheckSecrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppCheckSecrets.xcconfig; sourceTree = "<group>"; };
+		738B4A312AA8FE800056885D /* AppCheckSecretReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCheckSecretReader.swift; sourceTree = "<group>"; };
 		738D5F722A26BC3B00A7F11B /* BirthdayLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthdayLoader.swift; sourceTree = "<group>"; };
 		73A065612A786D10007BC7FC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		73A464002A1C3B3400BA8528 /* AppAttestExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppAttestExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -74,6 +76,7 @@
 				73A464032A1C3B3400BA8528 /* AppAttestExampleApp.swift */,
 				73A464052A1C3B3400BA8528 /* ContentView.swift */,
 				738D5F722A26BC3B00A7F11B /* BirthdayLoader.swift */,
+				738B4A312AA8FE800056885D /* AppCheckSecretReader.swift */,
 				738B4A302AA7EB840056885D /* AppCheckSecrets.xcconfig */,
 				73A065612A786D10007BC7FC /* Info.plist */,
 				73A464092A1C3B3500BA8528 /* Preview Content */,
@@ -211,6 +214,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				738D5F732A26BC3B00A7F11B /* BirthdayLoader.swift in Sources */,
+				738B4A322AA8FE800056885D /* AppCheckSecretReader.swift in Sources */,
 				73A464062A1C3B3400BA8528 /* ContentView.swift in Sources */,
 				73A464042A1C3B3400BA8528 /* AppAttestExampleApp.swift in Sources */,
 			);

--- a/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/xcshareddata/xcschemes/AppAttestExample.xcscheme
+++ b/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/xcshareddata/xcschemes/AppAttestExample.xcscheme
@@ -49,12 +49,6 @@
             ReferencedContainer = "container:AppAttestExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-FIRDebugEnabled"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/xcshareddata/xcschemes/AppAttestExample.xcscheme
+++ b/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/xcshareddata/xcschemes/AppAttestExample.xcscheme
@@ -49,13 +49,12 @@
             ReferencedContainer = "container:AppAttestExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "FIRAppCheckDebugToken"
-            value = "F40DF0E8-9CCC-46DF-AC01-43DE96FCEDD8"
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled"
             isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/xcshareddata/xcschemes/AppAttestExample.xcscheme
+++ b/Samples/Swift/AppAttestExample/AppAttestExample.xcodeproj/xcshareddata/xcschemes/AppAttestExample.xcscheme
@@ -49,15 +49,6 @@
             ReferencedContainer = "container:AppAttestExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-<<<<<<< HEAD
-=======
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-FIRDebugEnabled"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
->>>>>>> f25ca3f8211996119af8a5bd9cd1612664d69fa0
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Samples/Swift/AppAttestExample/AppAttestExample/AppAttestExampleApp.swift
+++ b/Samples/Swift/AppAttestExample/AppAttestExample/AppAttestExampleApp.swift
@@ -23,11 +23,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
   ) -> Bool {
     #if targetEnvironment(simulator)
-    guard let apiKey = Bundle.main.infoDictionary!["APP_CHECK_WEB_API_KEY"] as? String else {
-      print("Failed to get App_Check_WEB_API_KEY from Bundle.")
+    let secretReader = AppCheckSecretReader()
+    guard let APIKey = secretReader.APIKey else {
+      print("Unable to read API key from bundle or environment")
       return true
     }
-    GIDSignIn.sharedInstance.configureDebugProvider(withAPIKey: apiKey) { error in
+    GIDSignIn.sharedInstance.configureDebugProvider(withAPIKey: APIKey) { error in
       if let error {
         print("Error configuring `GIDSignIn` for Firebase App Check: \(error)")
       }

--- a/Samples/Swift/AppAttestExample/AppAttestExample/AppAttestExampleApp.swift
+++ b/Samples/Swift/AppAttestExample/AppAttestExample/AppAttestExampleApp.swift
@@ -22,17 +22,23 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
   ) -> Bool {
-    let useDebugProvider: Bool
     #if targetEnvironment(simulator)
-    useDebugProvider = true
-    #else
-    useDebugProvider = false
-    #endif
-    GIDSignIn.sharedInstance.configure(usingDebugProvider: useDebugProvider) { error in
+    guard let apiKey = Bundle.main.infoDictionary!["APP_CHECK_WEB_API_KEY"] as? String else {
+      print("Failed to get App_Check_WEB_API_KEY from Bundle.")
+      return true
+    }
+    GIDSignIn.sharedInstance.configureDebugProvider(withAPIKey: apiKey) { error in
       if let error {
         print("Error configuring `GIDSignIn` for Firebase App Check: \(error)")
       }
     }
+    #else
+    GIDSignIn.sharedInstance.configure { error in
+      if let error {
+        print("Error configuring `GIDSignIn` for Firebase App Check: \(error)")
+      }
+    }
+    #endif
 
     return true
   }

--- a/Samples/Swift/AppAttestExample/AppAttestExample/AppAttestExampleApp.swift
+++ b/Samples/Swift/AppAttestExample/AppAttestExample/AppAttestExampleApp.swift
@@ -22,19 +22,17 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
   ) -> Bool {
-    #if DEBUG
-    GIDSignIn.sharedInstance.configure(usingDebugProvider: true) { error in
-      if let error {
-        print("Error configuring `GIDSignIn` for Firebase App Check: \(error)")
-      }
-    }
+    let useDebugProvider: Bool
+    #if targetEnvironment(simulator)
+    useDebugProvider = true
     #else
-    GIDSignIn.sharedInstance.configure(usingDebugProvider: false) { error in
+    useDebugProvider = false
+    #endif
+    GIDSignIn.sharedInstance.configure(usingDebugProvider: useDebugProvider) { error in
       if let error {
         print("Error configuring `GIDSignIn` for Firebase App Check: \(error)")
       }
     }
-    #endif
 
     return true
   }

--- a/Samples/Swift/AppAttestExample/AppAttestExample/AppAttestExampleApp.swift
+++ b/Samples/Swift/AppAttestExample/AppAttestExample/AppAttestExampleApp.swift
@@ -22,11 +22,19 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
   ) -> Bool {
-    GIDSignIn.sharedInstance.configureWithCompletion { error in
+    #if DEBUG
+    GIDSignIn.sharedInstance.configure(usingDebugProvider: true) { error in
       if let error {
         print("Error configuring `GIDSignIn` for Firebase App Check: \(error)")
       }
     }
+    #else
+    GIDSignIn.sharedInstance.configure(usingDebugProvider: false) { error in
+      if let error {
+        print("Error configuring `GIDSignIn` for Firebase App Check: \(error)")
+      }
+    }
+    #endif
 
     return true
   }

--- a/Samples/Swift/AppAttestExample/AppAttestExample/AppCheckSecretReader.swift
+++ b/Samples/Swift/AppAttestExample/AppAttestExample/AppCheckSecretReader.swift
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+struct AppCheckSecretReader {
+  private let APIKeyName = "APP_CHECK_WEB_API_KEY"
+
+  var APIKey: String? {
+    return APIKeyFromBundle ?? APIKeyFromEnvironment
+  }
+
+  /// Method for retrieving API key from environment variable used during CI tests
+  private var APIKeyFromEnvironment: String? {
+    guard let APIKey = ProcessInfo.processInfo.environment[APIKeyName], !APIKey.isEmpty else {
+      print("Failed to get \(APIKeyName) from environment.")
+      return nil
+    }
+    return APIKey
+  }
+
+  /// Method for retrieving API key from the bundle during simulator or debug builds
+  private var APIKeyFromBundle: String? {
+    guard let APIKey = Bundle.main.infoDictionary?[APIKeyName] as? String,
+          !APIKey.isEmpty else {
+      print("Failed to get \(APIKeyName) from Bundle.")
+      return nil
+    }
+    return APIKey
+  }
+}

--- a/Samples/Swift/AppAttestExample/AppAttestExample/Info.plist
+++ b/Samples/Swift/AppAttestExample/AppAttestExample/Info.plist
@@ -2,20 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APP_CHECK_WEB_API_KEY</key>
+	<string>$(APP_CHECK_WEB_API_KEY)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>com.googleusercontent.apps.7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj</string>
+			<string>com.googleusercontent.apps.665845761721-a9g0c1k6buv131av6nnmburou5scd63h</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj</string>
+				<string>com.googleusercontent.apps.665845761721-a9g0c1k6buv131av6nnmburou5scd63h</string>
 			</array>
 		</dict>
 	</array>
 	<key>GIDClientID</key>
-	<string>7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj.apps.googleusercontent.com</string>
+	<string>665845761721-a9g0c1k6buv131av6nnmburou5scd63h.apps.googleusercontent.com</string>
 </dict>
 </plist>

--- a/Samples/Swift/AppAttestExample/AppAttestExample/Info.plist
+++ b/Samples/Swift/AppAttestExample/AppAttestExample/Info.plist
@@ -10,14 +10,14 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>com.googleusercontent.apps.7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj</string>
+			<string>com.googleusercontent.apps.665845761721-a9g0c1k6buv131av6nnmburou5scd63h</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj</string>
+				<string>com.googleusercontent.apps.665845761721-a9g0c1k6buv131av6nnmburou5scd63h</string>
 			</array>
 		</dict>
 	</array>
 	<key>GIDClientID</key>
-	<string>7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj.apps.googleusercontent.com</string>
+	<string>665845761721-a9g0c1k6buv131av6nnmburou5scd63h.apps.googleusercontent.com</string>
 </dict>
 </plist>

--- a/Samples/Swift/AppAttestExample/AppAttestExample/Info.plist
+++ b/Samples/Swift/AppAttestExample/AppAttestExample/Info.plist
@@ -8,14 +8,14 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>com.googleusercontent.apps.665845761721-a9g0c1k6buv131av6nnmburou5scd63h</string>
+			<string>com.googleusercontent.apps.7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.665845761721-a9g0c1k6buv131av6nnmburou5scd63h</string>
+				<string>com.googleusercontent.apps.7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj</string>
 			</array>
 		</dict>
 	</array>
 	<key>GIDClientID</key>
-	<string>665845761721-a9g0c1k6buv131av6nnmburou5scd63h.apps.googleusercontent.com</string>
+	<string>7094936827-l0b7c7l10jdbooi6r8s10ffq59ek04sj.apps.googleusercontent.com</string>
 </dict>
 </plist>

--- a/Samples/Swift/AppAttestExample/Podfile
+++ b/Samples/Swift/AppAttestExample/Podfile
@@ -1,3 +1,6 @@
+source 'https://github.com/CocoaPods/Specs.git'
+source 'https://github.com/firebase/SpecsDev.git'
+
 pod 'GoogleSignIn', :path => '../../../', :testspecs => ['unit']
 pod 'GoogleSignInSwiftSupport', :path => '../../../', :testspecs => ['unit']
 project 'AppAttestExample.xcodeproj'
@@ -5,6 +8,6 @@ project 'AppAttestExample.xcodeproj'
 use_frameworks! :linkage => :static
 
 target 'AppAttestExample' do
-  pod 'AppCheckCore', :git => 'https://github.com/google/app-check.git', :tag => 'CocoaPods-0.1.0-alpha.4'
+  pod 'AppCheckCore'
   platform :ios, '14.0'
 end

--- a/Samples/Swift/AppAttestExample/Podfile
+++ b/Samples/Swift/AppAttestExample/Podfile
@@ -5,6 +5,6 @@ project 'AppAttestExample.xcodeproj'
 use_frameworks! :linkage => :static
 
 target 'AppAttestExample' do
-  pod 'AppCheckCore', :git => 'https://github.com/google/app-check.git', :tag => 'CocoaPods-0.1.0-alpha.1'
+  pod 'AppCheckCore', :git => 'https://github.com/google/app-check.git', :tag => 'CocoaPods-0.1.0-alpha.4'
   platform :ios, '14.0'
 end


### PR DESCRIPTION
Updates `-[GIDSignIn configureWithCompletion:]` to be `-[GIDSignIn configureDebugProviderWithAPIKey:completion:]` so that clients can specify using a debug app check provider (e.g., when running on the simulator).