### PR TITLE
Do not modally animate the presenting of app check loading UI

### DIFF
--- a/GoogleSignIn/Sources/GIDAppCheck/UI/GIDActivityIndicatorViewController.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/UI/GIDActivityIndicatorViewController.m
@@ -24,6 +24,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  // Medium gray with transparency
   self.view.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:0.25];
 
   UIActivityIndicatorViewStyle style;

--- a/GoogleSignIn/Sources/GIDAppCheck/UI/GIDActivityIndicatorViewController.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/UI/GIDActivityIndicatorViewController.m
@@ -24,8 +24,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  self.view.backgroundColor = UIColor.blackColor;
-  self.view.alpha = 0.25;
+  self.view.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:0.25];
 
   UIActivityIndicatorViewStyle style;
   if (@available(iOS 13.0, *)) {

--- a/GoogleSignIn/Sources/GIDAppCheck/UI/GIDActivityIndicatorViewController.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/UI/GIDActivityIndicatorViewController.m
@@ -24,6 +24,8 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  self.view.backgroundColor = UIColor.blackColor;
+  self.view.alpha = 0.25;
 
   UIActivityIndicatorViewStyle style;
   if (@available(iOS 13.0, *)) {
@@ -32,6 +34,7 @@
     style = UIActivityIndicatorViewStyleGray;
   }
   _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:style];
+  _activityIndicator.color = UIColor.whiteColor;
   self.activityIndicator.translatesAutoresizingMaskIntoConstraints = NO;
   [self.activityIndicator startAnimating];
   [self.view addSubview:self.activityIndicator];

--- a/GoogleSignIn/Sources/GIDTimedLoader/GIDTimedLoader.m
+++ b/GoogleSignIn/Sources/GIDTimedLoader/GIDTimedLoader.m
@@ -68,9 +68,10 @@ CFTimeInterval const kGIDTimedLoaderMaxDelayBeforeAnimating = 0.5;
   self.loadingTimeStamp = CACurrentMediaTime();
   dispatch_async(dispatch_get_main_queue(), ^{
     // Since this loading VC may be reused, the activity indicator may have been stopped; restart it
+    self.loadingViewController.modalPresentationStyle = UIModalPresentationOverFullScreen;
     [self.loadingViewController.activityIndicator startAnimating];
     [self.presentingViewController presentViewController:self.loadingViewController
-                                                animated:YES
+                                                animated:NO
                                               completion:nil];
   });
 }
@@ -87,7 +88,7 @@ CFTimeInterval const kGIDTimedLoaderMaxDelayBeforeAnimating = 0.5;
   dispatch_after(deadline, dispatch_get_main_queue(), ^{
     self.animationStatus = GIDTimedLoaderAnimationStatusStopped;
     [self.loadingViewController.activityIndicator stopAnimating];
-    [self.loadingViewController dismissViewControllerAnimated:YES completion:nil];
+    [self.loadingViewController dismissViewControllerAnimated:NO completion:nil];
     completion();
   });
 }

--- a/GoogleSignIn/Sources/GIDTimedLoader/GIDTimedLoader.m
+++ b/GoogleSignIn/Sources/GIDTimedLoader/GIDTimedLoader.m
@@ -68,10 +68,12 @@ CFTimeInterval const kGIDTimedLoaderMaxDelayBeforeAnimating = 0.5;
   self.loadingTimeStamp = CACurrentMediaTime();
   dispatch_async(dispatch_get_main_queue(), ^{
     // Since this loading VC may be reused, the activity indicator may have been stopped; restart it
-    self.loadingViewController.modalPresentationStyle = UIModalPresentationOverFullScreen;
+    self.loadingViewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+    self.loadingViewController.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
+    self.presentingViewController.definesPresentationContext = YES;
     [self.loadingViewController.activityIndicator startAnimating];
     [self.presentingViewController presentViewController:self.loadingViewController
-                                                animated:NO
+                                                animated:YES
                                               completion:nil];
   });
 }
@@ -88,7 +90,7 @@ CFTimeInterval const kGIDTimedLoaderMaxDelayBeforeAnimating = 0.5;
   dispatch_after(deadline, dispatch_get_main_queue(), ^{
     self.animationStatus = GIDTimedLoaderAnimationStatusStopped;
     [self.loadingViewController.activityIndicator stopAnimating];
-    [self.loadingViewController dismissViewControllerAnimated:NO completion:nil];
+    [self.loadingViewController dismissViewControllerAnimated:YES completion:nil];
     completion();
   });
 }

--- a/Samples/Swift/AppAttestExample/AppAttestExampleForPod.xcodeproj/project.pbxproj
+++ b/Samples/Swift/AppAttestExample/AppAttestExampleForPod.xcodeproj/project.pbxproj
@@ -7,8 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7345556F2AB142B40068F2B0 /* AppCheckDefaultSecrets.json in Resources */ = {isa = PBXBuildFile; fileRef = 7345556D2AB142B40068F2B0 /* AppCheckDefaultSecrets.json */; };
-		734555702AB142B40068F2B0 /* AppCheckSecrets.json in Resources */ = {isa = PBXBuildFile; fileRef = 7345556E2AB142B40068F2B0 /* AppCheckSecrets.json */; };
+		734555A02AB39FBF0068F2B0 /* AppCheckDefaultSecrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7345559F2AB39FBF0068F2B0 /* AppCheckDefaultSecrets.xcconfig */; };
 		738B4A322AA8FE800056885D /* AppCheckSecretReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738B4A312AA8FE800056885D /* AppCheckSecretReader.swift */; };
 		738D5F732A26BC3B00A7F11B /* BirthdayLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738D5F722A26BC3B00A7F11B /* BirthdayLoader.swift */; };
 		73A464042A1C3B3400BA8528 /* AppAttestExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A464032A1C3B3400BA8528 /* AppAttestExampleApp.swift */; };
@@ -22,8 +21,7 @@
 		4728D878D216B7D622E237DA /* Pods_AppAttestExampleForPod.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppAttestExampleForPod.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73080B2A2AAF9BDE00DEF667 /* AppAttestExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAttestExampleTests.swift; sourceTree = "<group>"; };
 		73443A232A55F56900A4932E /* AppAttestExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AppAttestExample.entitlements; sourceTree = "<group>"; };
-		7345556D2AB142B40068F2B0 /* AppCheckDefaultSecrets.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = AppCheckDefaultSecrets.json; sourceTree = "<group>"; };
-		7345556E2AB142B40068F2B0 /* AppCheckSecrets.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = AppCheckSecrets.json; sourceTree = "<group>"; };
+		7345559F2AB39FBF0068F2B0 /* AppCheckDefaultSecrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = AppCheckDefaultSecrets.xcconfig; sourceTree = "<group>"; };
 		738B4A312AA8FE800056885D /* AppCheckSecretReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCheckSecretReader.swift; sourceTree = "<group>"; };
 		738D5F722A26BC3B00A7F11B /* BirthdayLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthdayLoader.swift; sourceTree = "<group>"; };
 		73A065612A786D10007BC7FC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -71,8 +69,7 @@
 		7345556C2AB142B40068F2B0 /* Secrets */ = {
 			isa = PBXGroup;
 			children = (
-				7345556D2AB142B40068F2B0 /* AppCheckDefaultSecrets.json */,
-				7345556E2AB142B40068F2B0 /* AppCheckSecrets.json */,
+				7345559F2AB39FBF0068F2B0 /* AppCheckDefaultSecrets.xcconfig */,
 			);
 			path = Secrets;
 			sourceTree = "<group>";
@@ -188,9 +185,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7345556F2AB142B40068F2B0 /* AppCheckDefaultSecrets.json in Resources */,
 				73A4640B2A1C3B3500BA8528 /* Preview Assets.xcassets in Resources */,
-				734555702AB142B40068F2B0 /* AppCheckSecrets.json in Resources */,
+				734555A02AB39FBF0068F2B0 /* AppCheckDefaultSecrets.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -255,6 +251,7 @@
 /* Begin XCBuildConfiguration section */
 		73A4640C2A1C3B3500BA8528 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7345559F2AB39FBF0068F2B0 /* AppCheckDefaultSecrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;


### PR DESCRIPTION
This PR updates the presentation of the loading UI when it takes more than 0.5 seconds to load the token. Previously, we would modally present a view controller with an activity indicator. That animation was awkward because it would pop the presenting view controller backwards, and overlay the loading UI. The updated presentation avoids that animation, and overlays a transparent gray view over the presenting view controller's view.

Before: https://github.com/google/GoogleSignIn-iOS/assets/4029922/ff8ede7b-118c-422b-94fa-0eb4c9a6b6b1
After: https://github.com/google/GoogleSignIn-iOS/assets/4029922/6eff3f98-09cb-4ade-84cc-1c30383dfa8c

