### PR TITLE
macOS build warning fix

### DIFF
--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GoogleSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GoogleSignIn.h
@@ -21,6 +21,4 @@
 #import "GIDSignIn.h"
 #import "GIDToken.h"
 #import "GIDSignInResult.h"
-#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 #import "GIDSignInButton.h"
-#endif


### PR DESCRIPTION
The umbrella header file,`GoogleSignIn.h`, contains `#if TARGET_OS_IOS || TARGET_OS_MACCATALYST` causes an Xcode build warning for macOS builds. This `#if` here is not needed given the underlying header file, `GIDSignInButton.h` already has this identical compiler conditional. Removing this `#if` in the umbrella header removes the macOS build warning and still continues to build successfully for iOS and Mac Catalyst.