### PR TITLE
Remove unnecessary TODO

### DIFF
--- a/GoogleSignIn/Sources/GIDGoogleUser.m
+++ b/GoogleSignIn/Sources/GIDGoogleUser.m
@@ -117,7 +117,6 @@ static NSTimeInterval const kMinimalTimeToExpire = 60.0;
   return _cachedConfiguration;
 }
 
-// TODO: Should the refresh tokens flow also use App Check? (mdmathias, 2023.05.23)
 - (void)refreshTokensIfNeededWithCompletion:(GIDGoogleUserCompletion)completion {
   if (!([self.accessToken.expirationDate timeIntervalSinceNow] < kMinimalTimeToExpire ||
       (self.idToken && [self.idToken.expirationDate timeIntervalSinceNow] < kMinimalTimeToExpire))) {


### PR DESCRIPTION
In this phase, we will only send the app check token in authorization requests to sign in via the UI flow.