### PR TITLE
Increase the max animation delay for App Check

### DIFF
--- a/GoogleSignIn/Sources/GIDTimedLoader/GIDTimedLoader.m
+++ b/GoogleSignIn/Sources/GIDTimedLoader/GIDTimedLoader.m
@@ -24,7 +24,7 @@
 #import "GoogleSignIn/Sources/GIDAppCheck/UI/GIDActivityIndicatorViewController.h"
 
 CFTimeInterval const kGIDTimedLoaderMinAnimationDuration = 1.0;
-CFTimeInterval const kGIDTimedLoaderMaxDelayBeforeAnimating = 0.5;
+CFTimeInterval const kGIDTimedLoaderMaxDelayBeforeAnimating = 0.8;
 
 @interface GIDTimedLoader ()
 


### PR DESCRIPTION
While we ask that developers pre-warm their apps to use App Check (i.e., generate the key and attestation object), we will still need to generate the assertion and execute a round trip with the backend to get the token sent with the sign in request. Testing on a real device shows that this averages somewhere within the range of approximate 0.6s to 1.0s.