### PR TITLE
Update AppCheckCore dependency to 10.18.0

### DIFF
--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -33,7 +33,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
   ]
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
-  s.dependency 'AppCheckCore', '~> 0.1.0-alpha.9'
+  s.dependency 'AppCheckCore', '~> 10.18'
   s.dependency 'AppAuth', '~> 1.6'
   s.dependency 'GTMAppAuth', '~> 4.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 1.1', '< 4.0'

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     .package(
       name: "AppCheck",
       url: "https://github.com/google/app-check.git",
-      .branch("CocoaPods-0.1.0-alpha.9")),
+      "10.18.0" ..< "11.0.0"),
     .package(
       name: "GTMAppAuth",
       url: "https://github.com/google/GTMAppAuth.git",

--- a/Samples/Swift/AppAttestExample/Podfile
+++ b/Samples/Swift/AppAttestExample/Podfile
@@ -1,5 +1,4 @@
 source 'https://github.com/CocoaPods/Specs.git'
-source 'https://github.com/firebase/SpecsDev.git'
 
 pod 'GoogleSignIn', :path => '../../../', :testspecs => ['unit']
 pod 'GoogleSignInSwiftSupport', :path => '../../../', :testspecs => ['unit']


### PR DESCRIPTION
`AppCheckCore` is now published to CocoaPods trunk (https://github.com/CocoaPods/Specs/blob/edf3929d945d1a1aff9c2fc96bc04db087fed6b7/Specs/3/b/6/AppCheckCore/10.18.0/AppCheckCore.podspec.json). Sourcing https://github.com/firebase/SpecsDev.git is no longer needed.