### PR TITLE
Clarifies that restored user is from local cache

### DIFF
--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -88,7 +88,7 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 
 /// Attempts to restore a previous user sign-in without interaction. 
 ///
-/// Restores user from the local cache and refreshes tokens if they have expired (<1 hour).
+/// Restores user from the local cache and refreshes tokens if they have expired (>1 hour).
 ///
 /// @param completion The block that is called on completion.  This block will be called asynchronously
 ///     on the main queue.

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -86,8 +86,9 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 /// @return `YES` if there is a previous user sign-in saved in keychain.
 - (BOOL)hasPreviousSignIn;
 
-/// Attempts to restore a previous user sign-in without interaction. Uses cached user and doesn't refresh
-/// tokens if the tokens haven't expired (<1 hour).
+/// Attempts to restore a previous user sign-in without interaction. 
+///
+/// Uses cached user and doesn't refresh tokens if the tokens haven't expired (<1 hour).
 ///
 /// @param completion The block that is called on completion.  This block will be called asynchronously
 ///     on the main queue.

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -88,7 +88,7 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 
 /// Attempts to restore a previous user sign-in without interaction. 
 ///
-/// Uses cached user and doesn't refresh tokens if the tokens haven't expired (<1 hour).
+/// Restores user from the local cache and refreshes tokens if they have expired (<1 hour).
 ///
 /// @param completion The block that is called on completion.  This block will be called asynchronously
 ///     on the main queue.

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -86,7 +86,8 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 /// @return `YES` if there is a previous user sign-in saved in keychain.
 - (BOOL)hasPreviousSignIn;
 
-/// Attempts to restore a previous user sign-in without interaction.
+/// Attempts to restore a previous user sign-in without interaction. Uses cached user and doesn't refresh
+/// tokens if the tokens haven't expired (<1 hour).
 ///
 /// @param completion The block that is called on completion.  This block will be called asynchronously
 ///     on the main queue.


### PR DESCRIPTION
This CL is in response to #346. To remove confusion I am adding to the `restorePreviousSignIn` docs that it will not refresh tokens if they are less than an hour old. 