### PR TITLE
Add extra_params argument to signin call

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -248,15 +248,21 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 - (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
                                       hint:(nullable NSString *)hint
                           additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                          additionalParams:(nullable NSDictionary *)extraParams
                                 completion:(nullable GIDSignInCompletion)completion {
-  GIDSignInInternalOptions *options =
+    GIDSignInInternalOptions *options =
     [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
                                      presentingViewController:presentingViewController
                                                     loginHint:hint
                                                 addScopesFlow:NO
                                                        scopes:additionalScopes
                                                    completion:completion];
-  [self signInWithOptions:options];
+    
+    if (extraParams != nil) {
+        options = [options optionsWithExtraParameters:extraParams forContinuation:NO];
+    }
+    
+    [self signInWithOptions:options];
 }
 
 - (void)signInWithPresentingViewController:(UIViewController *)presentingViewController

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -160,6 +160,7 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 - (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
                                       hint:(nullable NSString *)hint
                           additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                          additionalParams:(nullable NSDictionary *)extraParams
                                 completion:
     (nullable void (^)(GIDSignInResult *_Nullable signInResult,
                        NSError *_Nullable error))completion


### PR DESCRIPTION
I wanted to set a custom prompt https://developers.google.com/identity/openid-connect/openid-connect#prompt in the request so that I can always show the Google account list instead of automatically use the logged-in user.

But I couldn't find a way to do it inside this library.
What I saw is that AppAuth supports it by setting it in extraParams: https://github.com/openid/AppAuth-iOS/issues/6#issuecomment-298252225

The only problem is that I couldn't find a way to set these extraParams from outside of Google Sign in library.
So I added an extra params argument to the signin function and internally set them inside AppAuth call.