### PR TITLE
Remove pod try from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,9 @@ service.
 ## Getting Started
 
 Try either the [Objective-C](Samples/ObjC) or [Swift](Samples/Swift) sample app.
-For example, to demo the Objective-C sample project, you have three options:
+For example, to demo the Objective-C sample project, you have two options:
 
-1. Using [CocoaPods](https://cocoapods.org/)'s `try` method:
-
-```
-pod try GoogleSignIn
-```
-
-Note, this will default to providing you with the Objective-C sample app.
-
-2. Using CocoaPod's `install` method:
+1. Using CocoaPod's `install` method:
 
 ```
 git clone https://github.com/google/GoogleSignIn-iOS
@@ -35,7 +27,7 @@ pod install
 open SignInSampleForPod.xcworkspace
 ```
 
-3. Using [Swift Package Manager](https://swift.org/package-manager/):
+2. Using [Swift Package Manager](https://swift.org/package-manager/):
 
 ```
 git clone https://github.com/google/GoogleSignIn-iOS


### PR DESCRIPTION
pod try doesn't always seem to work due to local cache issues and isn't a convenient way to try out GSI. Moreover, the project hasn't received an update in approximately 4 years, which makes debugging more difficult due to a lack of activity.

#367 