### PR TITLE
Create GIDAccountDetailType enumeration and its mapping.

### DIFF
--- a/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifiableAccountDetail.m
+++ b/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifiableAccountDetail.m
@@ -17,4 +17,25 @@
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
 
 @implementation GIDVerifiableAccountDetail
+
+- (instancetype)initWithAccountDetailType:(GIDAccountDetailType)accountDetailType {
+   self = [super init];
+   if (self) {
+       _accountDetailType = accountDetailType;
+   }
+   return self;
+}
+
+// Returns dictionary mapping account detail type to scope.
++ (NSDictionary<NSNumber *, NSString *> *)scopeMapping {
+  return @{
+    @(GIDAccountDetailTypeAgeOver18) : @"https://www.googleapis.com/auth/verified.age.over18.standard"
+  };
+}
+
+- (NSString *)retrieveScope {
+    NSDictionary<NSNumber *, NSString *> *mapping = [GIDVerifiableAccountDetail scopeMapping];
+    return mapping[@(self.accountDetailType)]; 
+}
+
 @end

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h
@@ -16,7 +16,29 @@
 
 #import <Foundation/Foundation.h>
 
-/// Helper object used to hold GIDAccountDetailType representing a list of
+/// An enumeration defining the types of account details Google can verify.
+typedef NS_ENUM(NSInteger, GIDAccountDetailType) {
+    // Verifies the user is 18 years of age or older.
+    GIDAccountDetailTypeAgeOver18
+    // Potential future account details can be added here 
+};
+
+/// Helper object used to hold the enumeration representing a list of
 /// account details that Google can verify via GSI.
 @interface GIDVerifiableAccountDetail : NSObject
+
+// The type of account detail that will be verified.
+@property(nonatomic, readonly) GIDAccountDetailType accountDetailType;
+
+/// Initializes a new GIDVerifiableAccountDetail object with the given
+/// account detail type.
+///
+/// @param accountDetailType The type of account detail that will be verified.
+- (instancetype)initWithAccountDetailType:(GIDAccountDetailType)accountDetailType;
+
+/// Retrieves the scope required to verify the account detail.
+///
+/// @return A string representing the scope required to verify the account detail.
+- (NSString *)retrieveScope;
+
 @end

--- a/GoogleSignIn/Tests/Unit/GIDVerifiableAccountDetailTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDVerifiableAccountDetailTest.m
@@ -1,0 +1,23 @@
+#import <XCTest/XCTest.h>
+
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
+
+@interface GIDVerifiableAccountDetailTests : XCTestCase
+@end
+
+@implementation GIDVerifiableAccountDetailTests
+
+- (void)testDesignatedInitializer {
+  GIDVerifiableAccountDetail *detail = [[GIDVerifiableAccountDetail alloc] initWithAccountDetailType:GIDAccountDetailTypeAgeOver18];
+  XCTAssertNotNil(detail);
+  XCTAssertEqual(detail.accountDetailType, GIDAccountDetailTypeAgeOver18);
+}
+
+- (void)testScopeRetrieval {
+  GIDVerifiableAccountDetail *detail = [[GIDVerifiableAccountDetail alloc] initWithAccountDetailType:GIDAccountDetailTypeAgeOver18];
+  NSString *retrievedScope = [detail retrieveScope];
+  NSString *expectedScope = @"https://www.googleapis.com/auth/verified.age.over18.standard";
+  XCTAssertEqualObjects(retrievedScope, expectedScope);
+}
+
+@end


### PR DESCRIPTION
The enumeration `GIDAccountDetailType` is created and mapped to scope "https://www.googleapis.com/auth/verified.age.over18.standard". GIDVerifiableAccountDetail takes care of three functions: 
1. `-[GIDVerifiableAccountDetail initWithAccountDetailType:]`
Designated initializer of the GIDVerifiableAccountDetail class
2. `+[GIDVerifiableAccountDetail scopeMapping:]`
Returns a dictionary mapping account detail type to scope.
3. `-[GIDVerifiableAccountDetail retrieveScope:]`
Returns scope of account detail needed to verify.