### PR TITLE
Implement GIDVerifyAccountDetail interface methods to start interactive flow. 

### DIFF
--- a/GoogleSignIn/Sources/GIDConfiguration.m
+++ b/GoogleSignIn/Sources/GIDConfiguration.m
@@ -26,6 +26,12 @@ static NSString *const kHostedDomainKey = @"hostedDomain";
 // The key for the openIDRealm property to be used with NSSecureCoding.
 static NSString *const kOpenIDRealmKey = @"openIDRealm";
 
+// Info.plist config keys
+static NSString *const kConfigClientIDKey = @"GIDClientID";
+static NSString *const kConfigServerClientIDKey = @"GIDServerClientID";
+static NSString *const kConfigHostedDomainKey = @"GIDHostedDomain";
+static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation GIDConfiguration
@@ -57,6 +63,35 @@ NS_ASSUME_NONNULL_BEGIN
     _openIDRealm = [openIDRealm copy];
   }
   return self;
+}
+
+// Try to retrieve a configuration value from an |NSBundle|'s Info.plist for a given key.
++ (nullable NSString *)configValueFromBundle:(NSBundle *)bundle forKey:(NSString *)key {
+  NSString *value;
+  id configValue = [bundle objectForInfoDictionaryKey:key];
+  if ([configValue isKindOfClass:[NSString class]]) {
+    value = configValue;
+  }
+  return value;
+}
+
++ (nullable instancetype)configurationFromBundle:(NSBundle *)bundle {
+  // Retrieve any valid config parameters from the bundle's Info.plist.
+  NSString *clientID = [self configValueFromBundle:bundle forKey:kConfigClientIDKey];
+  NSString *serverClientID = [self configValueFromBundle:bundle
+                                                  forKey:kConfigServerClientIDKey];
+  NSString *hostedDomain = [self configValueFromBundle:bundle forKey:kConfigHostedDomainKey];
+  NSString *openIDRealm = [self configValueFromBundle:bundle forKey:kConfigOpenIDRealmKey];
+
+  // If we have at least a client ID, try to construct a configuration.
+  if (clientID) {
+    return [[self alloc] initWithClientID:clientID
+                           serverClientID:serverClientID
+                             hostedDomain:hostedDomain
+                              openIDRealm:openIDRealm];
+  }
+
+  return nil;
 }
 
 // Extend NSObject's default description for easier debugging.

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -135,12 +135,6 @@ static NSString *const kHostedDomainParameter = @"hd";
 // Minimum time to expiration for a restored access token.
 static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
 
-// Info.plist config keys
-static NSString *const kConfigClientIDKey = @"GIDClientID";
-static NSString *const kConfigServerClientIDKey = @"GIDServerClientID";
-static NSString *const kConfigHostedDomainKey = @"GIDHostedDomain";
-static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
-
 // The callback queue used for authentication flow.
 @interface GIDAuthFlow : GIDCallbackQueue
 

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -458,7 +458,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 
     // If we have a bundle, try to set the active configuration from the bundle's Info.plist.
     if (bundle) {
-      _configuration = [GIDSignIn configurationFromBundle:bundle];
+      _configuration = [GIDConfiguration configurationFromBundle:bundle];
     }
 
     // Check to see if the 3P app is being run for the first time after a fresh install.
@@ -1017,38 +1017,6 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
           givenName:idToken.claims[kBasicProfileGivenNameKey]
           familyName:idToken.claims[kBasicProfileFamilyNameKey]
             imageURL:[NSURL URLWithString:idToken.claims[kBasicProfilePictureKey]]];
-}
-
-// Try to retrieve a configuration value from an |NSBundle|'s Info.plist for a given key.
-+ (nullable NSString *)configValueFromBundle:(NSBundle *)bundle forKey:(NSString *)key {
-  NSString *value;
-  id configValue = [bundle objectForInfoDictionaryKey:key];
-  if ([configValue isKindOfClass:[NSString class]]) {
-    value = configValue;
-  }
-  return value;
-}
-
-// Try to generate a |GIDConfiguration| from an |NSBundle|'s Info.plist.
-+ (nullable GIDConfiguration *)configurationFromBundle:(NSBundle *)bundle {
-  GIDConfiguration *configuration;
-
-  // Retrieve any valid config parameters from the bundle's Info.plist.
-  NSString *clientID = [GIDSignIn configValueFromBundle:bundle forKey:kConfigClientIDKey];
-  NSString *serverClientID = [GIDSignIn configValueFromBundle:bundle
-                                                       forKey:kConfigServerClientIDKey];
-  NSString *hostedDomain = [GIDSignIn configValueFromBundle:bundle forKey:kConfigHostedDomainKey];
-  NSString *openIDRealm = [GIDSignIn configValueFromBundle:bundle forKey:kConfigOpenIDRealmKey];
-    
-  // If we have at least a client ID, try to construct a configuration.
-  if (clientID) {
-    configuration = [[GIDConfiguration alloc] initWithClientID:clientID
-                                                 serverClientID:serverClientID
-                                                   hostedDomain:hostedDomain
-                                                    openIDRealm:openIDRealm];
-  }
-  
-  return configuration;
 }
 
 @end

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.m
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
   GIDSignInInternalOptions *options = [[GIDSignInInternalOptions alloc] init];
   if (options) {
     options->_interactive = YES;
+    options->_continuation = NO; // Not relevant to VwG flow.
     options->_addScopesFlow = addScopesFlow;
     options->_configuration = configuration;
     options->_presentingViewController = presentingViewController;

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.m
@@ -36,7 +36,6 @@ NS_ASSUME_NONNULL_BEGIN
   GIDSignInInternalOptions *options = [[GIDSignInInternalOptions alloc] init];
   if (options) {
     options->_interactive = YES;
-    options->_continuation = NO;
     options->_addScopesFlow = addScopesFlow;
     options->_configuration = configuration;
     options->_presentingViewController = presentingViewController;

--- a/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifyAccountDetail.m
+++ b/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifyAccountDetail.m
@@ -42,10 +42,7 @@
                         hint:(nullable NSString *)hint
                   completion:(nullable void (^)(GIDVerifiedAccountDetailResult *_Nullable verifyResult,
                                                 NSError *_Nullable error))completion {
-  // Get the bundle of the current executable.
   NSBundle *bundle = NSBundle.mainBundle;
-
-  // If we have a bundle, try to set the active configuration from the bundle's Info.plist.
   if (bundle) {
     _configuration = [GIDConfiguration configurationFromBundle:bundle];
   }
@@ -61,7 +58,6 @@
   [self verifyAccountDetailsInteractivelyWithOptions:options];
 }
 
-// Starts authorization flow using the provided options.
 - (void)verifyAccountDetailsInteractivelyWithOptions:(GIDSignInInternalOptions *)options {
   // TODO(#397): Sanity checks and start the incremental authorization flow.
 }

--- a/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifyAccountDetail.m
+++ b/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifyAccountDetail.m
@@ -16,8 +16,12 @@
 
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h"
 
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDConfiguration.h"
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiedAccountDetailResult.h"
+
+#import "GoogleSignIn/Sources/GIDSignInInternalOptions.h"
+#import "GoogleSignIn/Sources/GIDSignInCallbackSchemes.h"
 
 #if TARGET_OS_IOS
 
@@ -45,6 +49,59 @@
                   completion:(nullable void (^)(GIDVerifiedAccountDetailResult *_Nullable verifyResult,
                                                 NSError *_Nullable error))completion {
   // TODO(#383): Implement this method.
+}
+
+// Starts authorization flow using the provided options.
+- (void)verifyAccountDetailsInteractivelyWithOptions:(GIDSignInInternalOptions *)options {
+  if (!options.interactive) {
+    return;
+  }
+  
+  // Ensure that a configuration is set.
+  if (!_configuration) {
+    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
+    [NSException raise:NSInvalidArgumentException
+                format:@"No active configuration. Make sure GIDClientID is set in Info.plist."];
+    return;    
+  }
+  
+  // Explicitly throw exception for missing client ID here. This must come before
+  // scheme check because schemes rely on reverse client IDs.
+  [self assertValidParameters:options];
+  
+  [self assertValidPresentingViewController:options];
+  
+  // If the application does not support the required URL schemes tell the developer so.
+  GIDSignInCallbackSchemes *schemes =
+  [[GIDSignInCallbackSchemes alloc] initWithClientIdentifier:options.configuration.clientID];
+  NSArray<NSString *> *unsupportedSchemes = [schemes unsupportedSchemes];
+  if (unsupportedSchemes.count != 0) {
+    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
+    [NSException raise:NSInvalidArgumentException
+                format:@"Your app is missing support for the following URL schemes: %@",
+     [unsupportedSchemes componentsJoinedByString:@", "]];
+  }
+  // TODO(#397): Start the incremental authorization flow.
+}
+
+#pragma mark - Helpers
+
+// Asserts the parameters being valid.
+- (void)assertValidParameters:(GIDSignInInternalOptions *)options {
+  if (![options.configuration.clientID length]) {
+    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
+    [NSException raise:NSInvalidArgumentException
+                format:@"You must specify |clientID| in |GIDConfiguration|"];
+  }
+}
+
+// Assert that the presenting view controller has been set.
+- (void)assertValidPresentingViewController:(GIDSignInInternalOptions *)options {
+  if (!options.presentingViewController) {
+    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
+    [NSException raise:NSInvalidArgumentException
+                format:@"|presentingViewController| must be set."];
+  }
 }
 
 @end

--- a/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifyAccountDetail.m
+++ b/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifyAccountDetail.m
@@ -31,7 +31,10 @@
     presentingViewController:(UIViewController *)presentingViewController
                   completion:(nullable void (^)(GIDVerifiedAccountDetailResult *_Nullable verifyResult,
                                                 NSError *_Nullable error))completion {
-  // TODO(#383): Implement this method.
+  [self verifyAccountDetails:accountDetails
+    presentingViewController:presentingViewController
+                        hint:nil
+                  completion:completion];
 }
 
 - (void)verifyAccountDetails:(NSArray<GIDVerifiableAccountDetail *> *)accountDetails
@@ -39,69 +42,28 @@
                         hint:(nullable NSString *)hint
                   completion:(nullable void (^)(GIDVerifiedAccountDetailResult *_Nullable verifyResult,
                                                 NSError *_Nullable error))completion {
-  // TODO(#383): Implement this method.
-}
+  // Get the bundle of the current executable.
+  NSBundle *bundle = NSBundle.mainBundle;
 
-- (void)verifyAccountDetails:(NSArray<GIDVerifiableAccountDetail *> *)accountDetails
-    presentingViewController:(UIViewController *)presentingViewController
-                        hint:(nullable NSString *)hint
-            additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                  completion:(nullable void (^)(GIDVerifiedAccountDetailResult *_Nullable verifyResult,
-                                                NSError *_Nullable error))completion {
-  // TODO(#383): Implement this method.
+  // If we have a bundle, try to set the active configuration from the bundle's Info.plist.
+  if (bundle) {
+    _configuration = [GIDConfiguration configurationFromBundle:bundle];
+  }
+
+  GIDSignInInternalOptions *options =
+  [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
+                                   presentingViewController:presentingViewController
+                                                  loginHint:hint
+                                              addScopesFlow:YES
+                                     accountDetailsToVerify:accountDetails
+                                           verifyCompletion:completion];
+
+  [self verifyAccountDetailsInteractivelyWithOptions:options];
 }
 
 // Starts authorization flow using the provided options.
 - (void)verifyAccountDetailsInteractivelyWithOptions:(GIDSignInInternalOptions *)options {
-  if (!options.interactive) {
-    return;
-  }
-  
-  // Ensure that a configuration is set.
-  if (!_configuration) {
-    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
-    [NSException raise:NSInvalidArgumentException
-                format:@"No active configuration. Make sure GIDClientID is set in Info.plist."];
-    return;    
-  }
-  
-  // Explicitly throw exception for missing client ID here. This must come before
-  // scheme check because schemes rely on reverse client IDs.
-  [self assertValidParameters:options];
-  
-  [self assertValidPresentingViewController:options];
-  
-  // If the application does not support the required URL schemes tell the developer so.
-  GIDSignInCallbackSchemes *schemes =
-  [[GIDSignInCallbackSchemes alloc] initWithClientIdentifier:options.configuration.clientID];
-  NSArray<NSString *> *unsupportedSchemes = [schemes unsupportedSchemes];
-  if (unsupportedSchemes.count != 0) {
-    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
-    [NSException raise:NSInvalidArgumentException
-                format:@"Your app is missing support for the following URL schemes: %@",
-     [unsupportedSchemes componentsJoinedByString:@", "]];
-  }
-  // TODO(#397): Start the incremental authorization flow.
-}
-
-#pragma mark - Helpers
-
-// Asserts the parameters being valid.
-- (void)assertValidParameters:(GIDSignInInternalOptions *)options {
-  if (![options.configuration.clientID length]) {
-    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
-    [NSException raise:NSInvalidArgumentException
-                format:@"You must specify |clientID| in |GIDConfiguration|"];
-  }
-}
-
-// Assert that the presenting view controller has been set.
-- (void)assertValidPresentingViewController:(GIDSignInInternalOptions *)options {
-  if (!options.presentingViewController) {
-    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
-    [NSException raise:NSInvalidArgumentException
-                format:@"|presentingViewController| must be set."];
-  }
+  // TODO(#397): Sanity checks and start the incremental authorization flow.
 }
 
 @end

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDConfiguration.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDConfiguration.h
@@ -71,6 +71,11 @@ NS_ASSUME_NONNULL_BEGIN
                     hostedDomain:(nullable NSString *)hostedDomain
                      openIDRealm:(nullable NSString *)openIDRealm NS_DESIGNATED_INITIALIZER;
 
+/// Try to generate a |GIDConfiguration| from an |NSBundle|'s Info.plist.
+///
+/// @param bundle The bundle to generate a configuration value.
++ (nullable instancetype)configurationFromBundle:(NSBundle *)bundle;                     
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h
@@ -28,6 +28,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class GIDConfiguration;
 @class GIDVerifiableAccountDetail;
 @class GIDVerifiedAccountDetailResult;
 
@@ -38,6 +39,9 @@ typedef void (^GIDVerifyCompletion)(GIDVerifiedAccountDetailResult *_Nullable ve
 
 /// This class is used to verify a user's Google account details.
 @interface GIDVerifyAccountDetail : NSObject
+
+/// The active configuration for this instance of `GIDVerifyAccountDetail`.
+@property(nonatomic, nullable) GIDConfiguration *configuration;
 
 /// Starts an interactive verification flow.
 ///

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h
@@ -72,24 +72,6 @@ typedef void (^GIDVerifyCompletion)(GIDVerifiedAccountDetailResult *_Nullable ve
                   completion:(nullable void (^)(GIDVerifiedAccountDetailResult *_Nullable verifyResult,
                                                 NSError *_Nullable error))completion;
 
-/// Starts an interactive verification flow using the provided hint and additional scopes.
-///
-/// The completion will be called at the end of this process.  Any saved verification
-/// state will be replaced by the result of this flow.
-///
-/// @param accountDetails A list of verifiable account details.
-/// @param presentingViewController The view controller used to present the flow.
-/// @param hint An optional hint for the authorization server, for example the user's ID or email
-///     address, to be prefilled if possible.
-/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
-/// @param completion The optional block called asynchronously on the main queue upon completion.
-- (void)verifyAccountDetails:(NSArray<GIDVerifiableAccountDetail *> *)accountDetails
-    presentingViewController:(UIViewController *)presentingViewController
-                        hint:(nullable NSString *)hint
-            additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
-                  completion:(nullable void (^)(GIDVerifiedAccountDetailResult *_Nullable verifyResult,
-                                                NSError *_Nullable error))completion;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Implement `GIDVerifyAccountDetail` interface methods to start interactive flow by creating an instance of `GIDSignInInternalOptions` and calling a method to start the authorization flow passing in those options. Additionally, methods to generate a new configuration was moved from `GIDSignIn` to `GIDConfiguration`. 

1. Add new method, `-[GIDVerifyAccountDetail verifyAccountDetailsInteractivelyWithOptions:]`, that will start the authorization flow.
2. Implement `GIDVerifyAccountDetail` interface methods to generate a configuration from bundle.
3. Create a `GIDSignInInternalOptions` instance and call `-[GIDVerifyAccountDetail verifyAccountDetailsInteractivelyWithOptions:]`.