### PR TITLE
Depend on GSI 7.1.0 in GoogleSignSwiftSupport.podspec

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,9 +20,10 @@ jobs:
           "",
           "--use-static-frameworks"
         ]
-        include:
-          - podspec: GoogleSignInSwiftSupport.podspec
-            includePodspecFlag: "--include-podspecs='GoogleSignIn.podspec'"
+        # See #400 (https://github.com/google/GoogleSignIn-iOS/issues/400)
+        # include:
+        #  - podspec: GoogleSignInSwiftSupport.podspec
+        #    includePodspecFlag: "--include-podspecs='GoogleSignIn.podspec'"
     steps:
     - uses: actions/checkout@v3
     - name: Update Bundler
@@ -33,7 +34,9 @@ jobs:
       run: |
         pod lib lint ${{ matrix.podspec }} --verbose \
            --sources=https://cdn.cocoapods.org/ \
-           ${{ matrix.includePodspecFlag }} ${{ matrix.flag }}
+           # See #400 (https://github.com/google/GoogleSignIn-iOS/issues/400)
+           # ${{ matrix.includePodspecFlag }} 
+           ${{ matrix.flag }}
 
   spm-build-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,11 +31,10 @@ jobs:
     - name: Install Ruby gems with Bundler
       run: bundle install
     - name: Lint podspec using local source
+      # See #400 (https://github.com/google/GoogleSignIn-iOS/issues/400)
       run: |
         pod lib lint ${{ matrix.podspec }} --verbose \
            --sources=https://cdn.cocoapods.org/ \
-           # See #400 (https://github.com/google/GoogleSignIn-iOS/issues/400)
-           # ${{ matrix.includePodspecFlag }} 
            ${{ matrix.flag }}
 
   spm-build-test:

--- a/GoogleSignInSwiftSupport.podspec
+++ b/GoogleSignInSwiftSupport.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     'CoreGraphics',
     'SwiftUI',
   ]
-  s.dependency 'GoogleSignIn', '~> 7.1.0-fac-beta-1.1.0'
+  s.dependency 'GoogleSignIn', '~> 7.1'
   s.resource_bundles = {
     'GoogleSignInSwiftSupport_Privacy' => 'GoogleSignInSwift/Sources/Resources/PrivacyInfo.xcprivacy'
   }


### PR DESCRIPTION
This change makes it so that `GoogleSignInSwiftSupport.podspec` depends upon v7.1.0 (and up) on CocoaPods instead of `"7.1.0-fac-beta-1.1.0`". This helps to avoid needing to release a new version of `GoogleSignInSwiftSupport` on CocoaPods, which would be required if we changed `GoogleSignInSwiftSupport`'s GSI dependency version.

SKIP_INTEGRATION_TESTS=YES