### PR TITLE
Remove GTMSessionFetcher module import

### DIFF
--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDGoogleUser.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDGoogleUser.h
@@ -23,11 +23,7 @@
 #import <AppKit/AppKit.h>
 #endif
 
-#ifdef SWIFT_PACKAGE
-@import GTMSessionFetcherCore;
-#else
 #import <GTMSessionFetcher/GTMSessionFetcher.h>
-#endif
 
 @class GIDConfiguration;
 @class GIDSignInResult;


### PR DESCRIPTION
This change removes the modular import of `GTMSessionFetcher` in `GIDGoogleUser.h` (e.g., `@import GTMSessionFetcher`) when building under `SWIFT_PACKAGE` in favor of `#import <GTMSessionFetcher/GTMSessionFetcher.h>`. The intention is to address lldb crashes when `po`ing in the debug console when projects use both SPM and CocoaPods.

Fixes #396 