### PR TITLE
Update SignInView.swift

### DIFF
--- a/Samples/Swift/DaysUntilBirthday/Shared/Views/SignInView.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Views/SignInView.swift
@@ -19,7 +19,7 @@ import GoogleSignInSwift
 
 struct SignInView: View {
   @EnvironmentObject var authViewModel: AuthenticationViewModel
-  @ObservedObject var vm = GoogleSignInButtonViewModel()
+  @StateObject var vm = GoogleSignInButtonViewModel()
 
   var body: some View {
     VStack {


### PR DESCRIPTION
Fix issue with declaration of GoogleSignInButtonViewModel variable. Switching to @StateObject from @ObservedObject allows to customize the button using constructor, otherwise - the customization doesn't work.