### PR TITLE
Update library to version 8

### DIFF
--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleSignIn'
-  s.version          = '7.2.0'
+  s.version          = '8.0.0'
   s.summary          = 'Enables iOS apps to sign in with Google.'
   s.description      = <<-DESC
 The Google Sign-In SDK allows users to sign in with their Google account from third-party apps.

--- a/GoogleSignInSwiftSupport.podspec
+++ b/GoogleSignInSwiftSupport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'GoogleSignInSwiftSupport'
-  s.version = '7.2.0'
+  s.version = '8.0.0'
   s.swift_version = '5.0'
   s.summary = 'Adds Swift-focused support for Google Sign-In.'
   s.description = 'Additional Swift support for the Google Sign-In SDK.'
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     'CoreGraphics',
     'SwiftUI',
   ]
-  s.dependency 'GoogleSignIn', '~> 7.2'
+  s.dependency 'GoogleSignIn', '~> 8.0'
   s.resource_bundles = {
     'GoogleSignInSwiftSupport_Privacy' => 'GoogleSignInSwift/Sources/Resources/PrivacyInfo.xcprivacy'
   }


### PR DESCRIPTION
Per #445, we need to increment GSI's version to 8 since we're incrementing our minimum iOS version to 12.