### PR TITLE
Fix bug to check for verify completion property in internal options instead of sign in's.

### DIFF
--- a/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifyAccountDetail.m
+++ b/GoogleSignIn/Sources/GIDVerifyAccountDetail/Implementations/GIDVerifyAccountDetail.m
@@ -185,7 +185,7 @@ NSErrorDomain const kGIDVerifyErrorDomain = @"com.google.GIDVerifyAccountDetail"
   additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
   additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
 
-  NSMutableArray *scopes;
+  NSMutableArray *scopes = [[NSMutableArray alloc] init];
   for (GIDVerifiableAccountDetail *detail in options.accountDetailsToVerify) {
     NSString *scopeString = [detail scope];
     if (scopeString) {
@@ -262,7 +262,7 @@ NSErrorDomain const kGIDVerifyErrorDomain = @"com.google.GIDVerifyAccountDetail"
   __weak GIDAuthFlow *weakAuthFlow = authFlow;
   [authFlow addCallback:^() {
     GIDAuthFlow *handlerAuthFlow = weakAuthFlow;
-    if (self->_options.completion) {
+    if (self->_options.verifyCompletion) {
       GIDVerifyCompletion completion = self->_options.verifyCompletion;
       self->_options = nil;
       dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
The following will ensure once the `addCompletionCallback` method is called, `verifyCompletion` in our internal options is checked whereas currently the completion property for the sign-in flow is being checked. Also, the following initializes  our scopes array with NSMutableArray to prevent dump values.