### PR TITLE
Update AppCheckCore dependency to v11

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-latest]
   
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,7 +47,7 @@ jobs:
         fi
 
   swift-button-functional-test:
-    runs-on: macOS-12
+    runs-on: macos-latest
     needs: check-pr-body-for-key
     # Don't run if triggered by a PR from a fork since our Secrets won't be provided to the runner.
     if: ${{ needs.check-pr-body-for-key.outputs.RUN_INTEGRATION == 'yes' && !github.event.pull_request.head.repo.fork }}
@@ -64,7 +64,7 @@ jobs:
           build-for-testing \
           -scheme DaysUntilBirthday\ \(iOS\) \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 11'
+          -destination 'platform=iOS Simulator,name=iPhone 14'
     - name: Run test target for Google Sign-in button for Swift
       env:
         EMAIL_SECRET : ${{ secrets.EMAIL_SECRET }}
@@ -75,7 +75,7 @@ jobs:
           test-without-building \
           -scheme DaysUntilBirthday\ \(iOS\) \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 11' \
+          -destination 'platform=iOS Simulator,name=iPhone 14' \
           EMAIL_SECRET=$EMAIL_SECRET \
           PASSWORD_SECRET=$PASSWORD_SECRET
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -64,7 +64,7 @@ jobs:
           build-for-testing \
           -scheme DaysUntilBirthday\ \(iOS\) \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 14'
+          -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.4'
     - name: Run test target for Google Sign-in button for Swift
       env:
         EMAIL_SECRET : ${{ secrets.EMAIL_SECRET }}
@@ -75,7 +75,7 @@ jobs:
           test-without-building \
           -scheme DaysUntilBirthday\ \(iOS\) \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 14' \
+          -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.4' \
           EMAIL_SECRET=$EMAIL_SECRET \
           PASSWORD_SECRET=$PASSWORD_SECRET
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-latest]
         sdk: ['macosx', 'iphonesimulator']
         include:
           - sdk: 'macosx'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
           - sdk: 'macosx'
             destination: '"platform=OS X,arch=x86_64"'
           - sdk: 'iphonesimulator'
-            destination: '"platform=iOS Simulator,name=iPhone 11"'
+            destination: '"platform=iOS Simulator,name=iPhone 14"'
     steps:
     - uses: actions/checkout@v3
     - name: Build unit test target

--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -33,7 +33,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
   ]
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
-  s.dependency 'AppCheckCore', '>= 10.19.1', '< 11.0'
+  s.dependency 'AppCheckCore', '~> 11.0'
   s.dependency 'AppAuth', '>= 1.7.3', '< 2.0'
   s.dependency 'GTMAppAuth', '>= 4.1.1', '< 5.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 3.3'
@@ -56,7 +56,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
     ]
     unit_tests.requires_app_host = true
     unit_tests.dependency 'OCMock'
-    unit_tests.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.13'
-    unit_tests.dependency 'GoogleUtilities/SwizzlerTestHelpers', '~> 7.13'
+    unit_tests.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.0'
+    unit_tests.dependency 'GoogleUtilities/SwizzlerTestHelpers', '~> 8.0'
   end
 end

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     .package(
       name: "AppCheck",
       url: "https://github.com/google/app-check.git",
-      "10.19.1" ..< "11.0.0"),
+      from: "11.0.0"),
     .package(
       name: "GTMAppAuth",
       url: "https://github.com/google/GTMAppAuth.git",
@@ -64,7 +64,7 @@ let package = Package(
     .package(
       name: "GoogleUtilities",
       url: "https://github.com/google/GoogleUtilities.git",
-      from: "7.13.0"),
+      from: "8.0.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Copyright 2021 Google LLC

--- a/Samples/Swift/DaysUntilBirthday/Shared/Services/Foo.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Services/Foo.swift
@@ -1,8 +1,0 @@
-//
-//  Foo.swift
-//  DaysUntilBirthday
-//
-//  Created by Matt Mathias on 7/11/24.
-//
-
-import Foundation

--- a/Samples/Swift/DaysUntilBirthday/Shared/Services/Foo.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Services/Foo.swift
@@ -1,0 +1,8 @@
+//
+//  Foo.swift
+//  DaysUntilBirthday
+//
+//  Created by Matt Mathias on 7/11/24.
+//
+
+import Foundation


### PR DESCRIPTION
GoogleUtilities also has to be updated to v8 because that is AppCheckCore's version for this dependency.

Fixes #444 