### PR TITLE
Fix Undefined symbols issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -71,6 +71,7 @@ let package = Package(
       name: "GoogleSignIn",
       dependencies: [
         .product(name: "AppAuth", package: "AppAuth"),
+        .product(name: "AppAuthCore", package: "AppAuth"),
         .product(name: "AppCheckCore", package: "AppCheck"),
         .product(name: "GTMAppAuth", package: "GTMAppAuth"),
         .product(name: "GTMSessionFetcherCore", package: "GTMSessionFetcher"),


### PR DESCRIPTION
Add AppAuthCore as explicit dependency to GoogleSignIn target as there are symbols that it uses from that library.

It is needed where GoogleSignIn is used as dynamic library/framework. This is the case when GoogleSignIn is added to multiple targets in dependency graph where 2 dynamic libraries/frameworks exist. 

Example of it can be seen in project that @cjwirth provided in #408.

Fixes: https://github.com/google/GoogleSignIn-iOS/issues/408

