### PR TITLE
#471 Proper user has canceled login error code.

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -803,7 +803,8 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   } else {
     NSString *errorString = [error localizedDescription];
     GIDSignInErrorCode errorCode = kGIDSignInErrorCodeUnknown;
-    if (error.code == OIDErrorCodeUserCanceledAuthorizationFlow) {
+    if (error.code == OIDErrorCodeUserCanceledAuthorizationFlow ||
+        error.code == OIDErrorCodeProgramCanceledAuthorizationFlow) {
       // The user has canceled the flow at the iOS modal dialog.
       errorString = kUserCanceledError;
       errorCode = kGIDSignInErrorCodeCanceled;


### PR DESCRIPTION
This should fix [#471](https://github.com/google/GoogleSignIn-iOS/issues/471) and related issue [#1327](https://github.com/react-native-google-signin/google-signin/issues/1327) in react-native-google-signin.