### PR TITLE
Throw an exception if verified age scope is passed in sign-in request through the add scopes flow.

### DIFF
--- a/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h
+++ b/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/// A registry to manage restricted scopes and their associated handling classes to track scopes
+/// that require separate flows within an application.
+@interface GIDRestrictedScopesRegistry : NSObject
+
+/// A set of strings representing the restricted scopes.
+@property (nonatomic, strong, readonly) NSSet<NSString *> *restrictedScopes;
+
+/// A dictionary mapping restricted scopes to their corresponding handling classes.
+@property (nonatomic, strong, readonly) NSDictionary<NSString *, Class> *scopeToClassMapping;
+
+/// This designated initializer sets up the initial restricted scopes and their corresponding handling classes.
+///
+/// @return An initialized `GIDRestrictedScopesRegistry` instance
+- (instancetype)init;
+
+/// Checks if a given scope is restricted.
+///
+/// @param scope The scope to check.
+/// @return YES if the scope is restricted; otherwise, NO.
+- (BOOL)isScopeRestricted:(NSString *)scope;
+
+/// Retrieves a dictionary mapping restricted scopes to their handling classes within a given set of scopes.
+///
+/// @param scopes A set of scopes.
+/// @return A dictionary where restricted scopes found in the input set are mapped to their corresponding handling classes.
+///     If no restricted scopes are found, an empty dictionary is returned.
+- (NSDictionary<NSString *, Class> *)restrictedScopeToClassMappingInSet:(NSSet<NSString *> *)scopes;
+
+@end

--- a/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h
+++ b/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+
 #import <Foundation/Foundation.h>
 
 /// A registry to manage restricted scopes and their associated handling classes to track scopes
@@ -45,3 +49,5 @@
 - (NSDictionary<NSString *, Class> *)restrictedScopeToClassMappingInSet:(NSSet<NSString *> *)scopes;
 
 @end
+
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h
+++ b/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h
@@ -43,10 +43,10 @@
 
 /// Retrieves a dictionary mapping restricted scopes to their handling classes within a given set of scopes.
 ///
-/// @param scopes A set of scopes.
+/// @param scopes A set of scopes to lookup their handling class.
 /// @return A dictionary where restricted scopes found in the input set are mapped to their corresponding handling classes.
 ///     If no restricted scopes are found, an empty dictionary is returned.
-- (NSDictionary<NSString *, Class> *)restrictedScopeToClassMappingInSet:(NSSet<NSString *> *)scopes;
+- (NSDictionary<NSString *, Class> *)restrictedScopesToClassMappingInSet:(NSSet<NSString *> *)scopes;
 
 @end
 

--- a/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.m
+++ b/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.m
@@ -17,6 +17,8 @@
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h"
 
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+
 @implementation GIDRestrictedScopesRegistry
 
 - (instancetype)init {
@@ -46,3 +48,5 @@
 }
 
 @end
+
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.m
+++ b/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.m
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h"
+
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h"
+
+@implementation GIDRestrictedScopesRegistry
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _restrictedScopes = [NSSet setWithObjects:kAccountDetailTypeAgeOver18Scope, nil];
+    _scopeToClassMapping = @{
+      kAccountDetailTypeAgeOver18Scope: [GIDVerifyAccountDetail class],
+    };
+  }
+  return self;
+}
+
+- (BOOL)isScopeRestricted:(NSString *)scope {
+  return [self.restrictedScopes containsObject:scope];
+}
+
+- (NSDictionary<NSString *, Class> *)restrictedScopeToClassMappingInSet:(NSSet<NSString *> *)scopes {
+  NSMutableDictionary<NSString *, Class> *mapping = [NSMutableDictionary dictionary];
+  for (NSString *scope in scopes) {
+    if ([self isScopeRestricted:scope]) {
+      Class handlingClass = self.scopeToClassMapping[scope];
+      mapping[scope] = handlingClass;
+    }
+  }
+  return [mapping copy];
+}
+
+@end

--- a/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.m
+++ b/GoogleSignIn/Sources/GIDRestrictedScopesRegistry.m
@@ -36,7 +36,7 @@
   return [self.restrictedScopes containsObject:scope];
 }
 
-- (NSDictionary<NSString *, Class> *)restrictedScopeToClassMappingInSet:(NSSet<NSString *> *)scopes {
+- (NSDictionary<NSString *, Class> *)restrictedScopesToClassMappingInSet:(NSSet<NSString *> *)scopes {
   NSMutableDictionary<NSString *, Class> *mapping = [NSMutableDictionary dictionary];
   for (NSString *scope in scopes) {
     if ([self isScopeRestricted:scope]) {

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -508,6 +508,7 @@ static NSString *const kClientAssertionTypeParameterValue =
                               callbackPath:kBrowserCallbackPath
                               keychainName:kGTMAppAuthKeychainName
                             isFreshInstall:isFreshInstall];
+    _registry = [[GIDRestrictedScopesRegistry alloc] init];
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   }
   return self;
@@ -1000,7 +1001,6 @@ static NSString *const kClientAssertionTypeParameterValue =
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)assertValidScopes:(NSArray<NSString *> *)scopes {
-  _registry = [[GIDRestrictedScopesRegistry alloc] init];
   NSDictionary<NSString *, Class> *restrictedScopesMapping =
       [_registry restrictedScopesToClassMappingInSet:[NSSet setWithArray:scopes]];
 

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -1001,15 +1001,22 @@ static NSString *const kClientAssertionTypeParameterValue =
   NSDictionary *scopeToClassMapping = @{
     kAccountDetailTypeAgeOver18Scope : [GIDVerifyAccountDetail class],
   };
+  NSMutableString *errorMessage =
+    [NSMutableString stringWithString:@"The following scopes are not supported in the 'addScopes' flow. "
+                                       "Please use the appropriate classes to handle these:\n"];
+  Boolean unsupportedScopeFound = NO;
+
   for (NSString *scope in scopes) {
     Class scopeClass = scopeToClassMapping[scope];
     if (scopeClass) {
-      // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
-      [NSException raise:NSInvalidArgumentException
-                  format:@"Scope %@ requires using %@. "
-                         "Do not pass in through add scopes flow in `GIDSignIn`.",
-                         scope, NSStringFromClass(scopeClass)];
+      unsupportedScopeFound = YES;
+      [errorMessage appendFormat:@"%@ -> %@\n", scope, NSStringFromClass(scopeClass)];
     }
+  }
+  if (unsupportedScopeFound) {
+    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
+    [NSException raise:NSInvalidArgumentException
+                format:@"%@", errorMessage];
   }
 }
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -21,6 +21,7 @@
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDProfileData.h"
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignInResult.h"
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h"
 
 #import "GoogleSignIn/Sources/GIDAuthorizationResponse/GIDAuthorizationResponseHelper.h"
 #import "GoogleSignIn/Sources/GIDAuthorizationResponse/Implementations/GIDAuthorizationResponseHandler.h"

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -258,9 +258,10 @@ static NSString *const kClientAssertionTypeParameterValue =
                                                       loginHint:self.currentUser.profile.email
                                                   addScopesFlow:YES
                                                      completion:completion];
-
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   // Explicitly throw an exception for invalid or restricted scopes in the request.
   [self assertValidScopes:scopes];
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
@@ -332,9 +333,6 @@ static NSString *const kClientAssertionTypeParameterValue =
                                                       loginHint:self.currentUser.profile.email
                                                   addScopesFlow:YES
                                                      completion:completion];
-
-  // Explicitly throw an exception for invalid or restricted scopes in the request.
-  [self assertValidScopes:scopes];
 
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
@@ -997,6 +995,7 @@ static NSString *const kClientAssertionTypeParameterValue =
   }
 }
 
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 // Asserts the requested scopes are valid.
 - (void)assertValidScopes:(NSArray<NSString *> *)scopes {
   NSDictionary *scopeToClassMapping = @{
@@ -1013,6 +1012,7 @@ static NSString *const kClientAssertionTypeParameterValue =
     }
   }
 }
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 // Checks whether or not this is the first time the app runs.
 - (BOOL)isFreshInstall {

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -257,6 +257,10 @@ static NSString *const kClientAssertionTypeParameterValue =
                                                   addScopesFlow:YES
                                                      completion:completion];
 
+  // Explicitly throw an exception for invalid or restricted scopes in the request.
+  // This should be done in class GIDVerifyAccountDetail.
+  [self assertValidScopes:scopes];
+
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
       [NSMutableSet setWithArray:self.currentUser.grantedScopes];
@@ -327,6 +331,10 @@ static NSString *const kClientAssertionTypeParameterValue =
                                                       loginHint:self.currentUser.profile.email
                                                   addScopesFlow:YES
                                                      completion:completion];
+
+  // Explicitly throw an exception for invalid or restricted scopes in the request.
+  // This should be done in class GIDVerifyAccountDetail.
+  [self assertValidScopes:scopes];
 
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
@@ -986,6 +994,16 @@ static NSString *const kClientAssertionTypeParameterValue =
     // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
     [NSException raise:NSInvalidArgumentException
                 format:@"|presentingViewController| must be set."];
+  }
+}
+
+// Asserts the requested scopes are valid.
+- (void)assertValidScopes:(NSArray<NSString *> *)scopes {
+  if ([scopes containsObject:@"https://www.googleapis.com/auth/verified.age.over18.standard"]) {
+    // NOLINTNEXTLINE(google-objc-avoid-throwing-exception)
+    [NSException raise:NSInvalidArgumentException
+                format:@"Do not use `addScopes` on `GIDSignIn`. "
+                        "Instead, utilize `GIDVerifyAccountDetail` for age verification."];
   }
 }
 

--- a/GoogleSignIn/Tests/Unit/GIDRestrictedScopesRegistryTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDRestrictedScopesRegistryTest.m
@@ -14,6 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import "GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h"
 
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
@@ -38,3 +39,5 @@
 }
 
 @end
+
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Tests/Unit/GIDRestrictedScopesRegistryTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDRestrictedScopesRegistryTest.m
@@ -18,6 +18,7 @@
 #import "GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h"
 
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifyAccountDetail.h"
 
 @interface GIDRestrictedScopesRegistryTest : XCTestCase
 @end

--- a/GoogleSignIn/Tests/Unit/GIDRestrictedScopesRegistryTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDRestrictedScopesRegistryTest.m
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "GoogleSignIn/Sources/GIDRestrictedScopesRegistry.h"
+
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDVerifiableAccountDetail.h"
+
+@interface GIDRestrictedScopesRegistryTest : XCTestCase
+@end
+
+@implementation GIDRestrictedScopesRegistryTest
+- (void)testIsScopeRestricted {
+    GIDRestrictedScopesRegistry *registry = [[GIDRestrictedScopesRegistry alloc] init];
+    BOOL isRestricted = [registry isScopeRestricted:kAccountDetailTypeAgeOver18Scope];
+    XCTAssertTrue(isRestricted);
+}
+
+- (void)testRestrictedScopeToClassMappingInSet {
+    GIDRestrictedScopesRegistry *registry = [[GIDRestrictedScopesRegistry alloc] init];
+    NSSet<NSString *> *scopes = [NSSet setWithObjects:kAccountDetailTypeAgeOver18Scope, @"some_other_scope", nil];
+    NSDictionary<NSString *, Class> *mapping = [registry restrictedScopeToClassMappingInSet:scopes];
+
+    XCTAssertEqual(mapping.count, 1);
+    XCTAssertEqualObjects(mapping[kAccountDetailTypeAgeOver18Scope], [GIDVerifyAccountDetail class]);
+}
+
+@end

--- a/GoogleSignIn/Tests/Unit/GIDRestrictedScopesRegistryTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDRestrictedScopesRegistryTest.m
@@ -24,19 +24,21 @@
 @end
 
 @implementation GIDRestrictedScopesRegistryTest
+
 - (void)testIsScopeRestricted {
-    GIDRestrictedScopesRegistry *registry = [[GIDRestrictedScopesRegistry alloc] init];
-    BOOL isRestricted = [registry isScopeRestricted:kAccountDetailTypeAgeOver18Scope];
-    XCTAssertTrue(isRestricted);
+  GIDRestrictedScopesRegistry *registry = [[GIDRestrictedScopesRegistry alloc] init];
+  BOOL isRestricted = [registry isScopeRestricted:kAccountDetailTypeAgeOver18Scope];
+  XCTAssertTrue(isRestricted);
 }
 
-- (void)testRestrictedScopeToClassMappingInSet {
-    GIDRestrictedScopesRegistry *registry = [[GIDRestrictedScopesRegistry alloc] init];
-    NSSet<NSString *> *scopes = [NSSet setWithObjects:kAccountDetailTypeAgeOver18Scope, @"some_other_scope", nil];
-    NSDictionary<NSString *, Class> *mapping = [registry restrictedScopeToClassMappingInSet:scopes];
-
-    XCTAssertEqual(mapping.count, 1);
-    XCTAssertEqualObjects(mapping[kAccountDetailTypeAgeOver18Scope], [GIDVerifyAccountDetail class]);
+- (void)testRestrictedScopesToClassMappingInSet {
+  GIDRestrictedScopesRegistry *registry = [[GIDRestrictedScopesRegistry alloc] init];
+  NSSet<NSString *> *scopes = [NSSet setWithObjects:kAccountDetailTypeAgeOver18Scope, @"some_other_scope", nil];
+  NSDictionary<NSString *, Class> *mapping = [registry restrictedScopesToClassMappingInSet:scopes];
+  
+  XCTAssertEqual(mapping.count, 1);
+  XCTAssertEqualObjects(mapping[kAccountDetailTypeAgeOver18Scope], [GIDVerifyAccountDetail class]);
+  XCTAssertNil(mapping[@"some_other_scope"]);
 }
 
 @end

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -1300,9 +1300,6 @@ static NSString *const kNewScope = @"newScope";
   XCTAssertEqualObjects(_authError.domain, kGIDSignInErrorDomain);
   XCTAssertEqual(_authError.code, kGIDSignInErrorCodeEMM);
   XCTAssertNil(_signIn.currentUser, @"should not have current user");
-
-  // TODO: Keep mocks from carrying forward to subsequent tests. (#410)
-  [_authState stopMocking];
 }
 
 - (void)testValidScopesException {
@@ -1324,6 +1321,9 @@ presentingViewController:_presentingViewController
   } @finally {
   }
   XCTAssert(threw);
+
+  // TODO: Keep mocks from carrying forward to subsequent tests. (#410)
+  [_authState stopMocking];
 }
 
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -1305,6 +1305,27 @@ static NSString *const kNewScope = @"newScope";
   [_authState stopMocking];
 }
 
+- (void)testValidScopesException {
+  NSArray *requestedScopes = @[@"https://www.googleapis.com/auth/verified.age.over18.standard"];
+  BOOL threw = NO;
+  @try {
+    [_signIn addScopes:requestedScopes
+#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
+presentingViewController:_presentingViewController
+#elif TARGET_OS_OSX
+      presentingWindow:_presentingWindow
+#endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
+            completion:_completion];
+  } @catch (NSException *exception) {
+    threw = YES;
+    XCTAssertEqualObjects(exception.description,
+                          @"Do not use `addScopes` on `GIDSignIn`. "
+                           "Instead, utilize `GIDVerifyAccountDetail` for age verification.");
+  } @finally {
+  }
+  XCTAssert(threw);
+}
+
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 #pragma mark - Helpers

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -1304,9 +1304,10 @@ static NSString *const kNewScope = @"newScope";
 
 - (void)testValidScopesException {
   NSString *requestedScope = @"https://www.googleapis.com/auth/verified.age.over18.standard";
-  NSString *expectedException = [NSString stringWithFormat:@"Scope %@ requires using %@. "
-                                 "Do not pass in through add scopes flow in `GIDSignIn`.",
-                                 requestedScope, NSStringFromClass([GIDVerifyAccountDetail class])];
+  NSString *expectedException = 
+    [NSString stringWithFormat:@"The following scopes are not supported in the 'addScopes' flow. "
+                                "Please use the appropriate classes to handle these:\n%@ -> %@\n",
+                                requestedScope, NSStringFromClass([GIDVerifyAccountDetail class])];
   BOOL threw = NO;
   @try {
     [_signIn addScopes:@[requestedScope]

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -1303,21 +1303,22 @@ static NSString *const kNewScope = @"newScope";
 }
 
 - (void)testValidScopesException {
-  NSArray *requestedScopes = @[@"https://www.googleapis.com/auth/verified.age.over18.standard"];
+  NSString *requestedScope = @"https://www.googleapis.com/auth/verified.age.over18.standard";
+  NSString *expectedException = [NSString stringWithFormat:@"Scope %@ requires using %@. "
+                                 "Do not pass in through add scopes flow in `GIDSignIn`.",
+                                 requestedScope, NSStringFromClass([GIDVerifyAccountDetail class])];
   BOOL threw = NO;
   @try {
-    [_signIn addScopes:requestedScopes
+    [_signIn addScopes:@[requestedScope]
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
-presentingViewController:_presentingViewController
+      presentingViewController:_presentingViewController
 #elif TARGET_OS_OSX
       presentingWindow:_presentingWindow
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
             completion:_completion];
   } @catch (NSException *exception) {
     threw = YES;
-    XCTAssertEqualObjects(exception.description,
-                          @"Do not use `addScopes` on `GIDSignIn`. "
-                           "Instead, utilize `GIDVerifyAccountDetail` for age verification.");
+    XCTAssertEqualObjects(exception.description, expectedException);
   } @finally {
   }
   XCTAssert(threw);


### PR DESCRIPTION
If a developer passes verification age scope to addScopes method, this results in an error (invalid_request). Instead of having the developer run through documentation and figure out why it errors, we'll throw an exception to let the developer know to use `GIDVerifyAccountDetail` instead.