### PR TITLE
Fix passing nil for nonce and add example

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -926,11 +926,10 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   }
 
   [authFlow wait];
-  [OIDAuthorizationService
-   performTokenRequest:tokenRequest
-   originalAuthorizationResponse:authFlow.authState.lastAuthorizationResponse
-   callback:^(OIDTokenResponse *_Nullable tokenResponse,
-              NSError *_Nullable error) {
+  [OIDAuthorizationService performTokenRequest:tokenRequest
+                 originalAuthorizationResponse:authFlow.authState.lastAuthorizationResponse
+                                      callback:^(OIDTokenResponse *_Nullable tokenResponse,
+                                                 NSError *_Nullable error) {
     [authState updateWithTokenResponse:tokenResponse error:error];
     authFlow.error = error;
 

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -726,14 +726,23 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 - (OIDAuthorizationRequest *)
     authorizationRequestWithOptions:(GIDSignInInternalOptions *)options
                additionalParameters:(NSDictionary<NSString *, NSString *> *)additionalParameters {
-  OIDAuthorizationRequest *request =
-      [[OIDAuthorizationRequest alloc] initWithConfiguration:_appAuthConfiguration
-                                                    clientId:options.configuration.clientID
-                                                      scopes:options.scopes
-                                                 redirectURL:[self redirectURLWithOptions:options]
-                                                responseType:OIDResponseTypeCode
-                                                       nonce:options.nonce
-                                        additionalParameters:additionalParameters];
+  OIDAuthorizationRequest *request;
+  if (options.nonce) {
+    request = [[OIDAuthorizationRequest alloc] initWithConfiguration:_appAuthConfiguration
+                                                            clientId:options.configuration.clientID
+                                                              scopes:options.scopes
+                                                         redirectURL:[self redirectURLWithOptions:options]
+                                                        responseType:OIDResponseTypeCode
+                                                               nonce:options.nonce
+                                                additionalParameters:additionalParameters];
+  } else {
+    request = [[OIDAuthorizationRequest alloc] initWithConfiguration:_appAuthConfiguration
+                                                            clientId:options.configuration.clientID
+                                                              scopes:options.scopes
+                                                         redirectURL:[self redirectURLWithOptions:options]
+                                                        responseType:OIDResponseTypeCode
+                                                additionalParameters:additionalParameters];
+  }
   return request;
 }
 
@@ -918,9 +927,10 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 
   [authFlow wait];
   [OIDAuthorizationService
-      performTokenRequest:tokenRequest
-                 callback:^(OIDTokenResponse *_Nullable tokenResponse,
-                            NSError *_Nullable error) {
+   performTokenRequest:tokenRequest
+   originalAuthorizationResponse:authFlow.authState.lastAuthorizationResponse
+   callback:^(OIDTokenResponse *_Nullable tokenResponse,
+              NSError *_Nullable error) {
     [authState updateWithTokenResponse:tokenResponse error:error];
     authFlow.error = error;
 

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -297,7 +297,7 @@ static NSString *const kNewScope = @"newScope";
 #elif TARGET_OS_OSX
   _presentingWindow = OCMStrictClassMock([NSWindow class]);
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
-  _authState = OCMStrictClassMock([OIDAuthState class]);
+  _authState = OCMClassMock([OIDAuthState class]);
   OCMStub([_authState alloc]).andReturn(_authState);
   OCMStub([_authState initWithAuthorizationResponse:OCMOCK_ANY]).andReturn(_authState);
   _tokenResponse = OCMStrictClassMock([OIDTokenResponse class]);
@@ -327,7 +327,8 @@ static NSString *const kNewScope = @"newScope";
                          callback:COPY_TO_ARG_BLOCK(self->_savedAuthorizationCallback)]);
   OCMStub([self->_oidAuthorizationService
       performTokenRequest:SAVE_TO_ARG_BLOCK(self->_savedTokenRequest)
-                 callback:COPY_TO_ARG_BLOCK(self->_savedTokenCallback)]);
+      originalAuthorizationResponse:[OCMArg any]
+      callback:COPY_TO_ARG_BLOCK(self->_savedTokenCallback)]);
 
   // Fakes
   _fetcherService = [[GIDFakeFetcherService alloc] init];

--- a/Samples/Swift/DaysUntilBirthday/Shared/Services/GoogleSignInAuthenticator.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Services/GoogleSignInAuthenticator.swift
@@ -52,7 +52,7 @@ final class GoogleSignInAuthenticator: ObservableObject {
       guard let idToken = signInResult.user.idToken?.tokenString,
             let returnedNonce = self.decodeNonce(fromJWT: idToken),
             returnedNonce == manualNonce else {
-        // Assert a failure for convenience so that integration tests with thissample app fail upon
+        // Assert a failure for convenience so that integration tests with this sample app fail upon
         // `nonce` mismatch
         assertionFailure("ERROR: Returned nonce doesn't match manual nonce!")
         return

--- a/Samples/Swift/DaysUntilBirthday/Shared/Services/GoogleSignInAuthenticator.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Services/GoogleSignInAuthenticator.swift
@@ -35,10 +35,24 @@ final class GoogleSignInAuthenticator: ObservableObject {
       print("There is no root view controller!")
       return
     }
+    let manualNonce = UUID().uuidString
 
-    GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController) { signInResult, error in
+    GIDSignIn.sharedInstance.signIn(
+      withPresenting: rootViewController,
+      hint: nil,
+      additionalScopes: nil,
+      nonce: manualNonce
+    ) { signInResult, error in
       guard let signInResult = signInResult else {
         print("Error! \(String(describing: error))")
+        return
+      }
+
+      // Per OpenID Connect Core section 3.1.3.7, rule #11, compare returned nonce to manual
+      guard let idToken = signInResult.user.idToken?.tokenString,
+            let returnedNonce = self.decodeNonce(fromJWT: idToken),
+            returnedNonce == manualNonce else {
+        print("ERROR: Returned nonce doesn't match manual nonce!")
         return
       }
       self.authViewModel.state = .signedIn(signInResult.user)
@@ -124,4 +138,41 @@ final class GoogleSignInAuthenticator: ObservableObject {
     #endif
   }
 
+}
+
+// MARK: Parse nonce from JWT ID Token
+
+private extension GoogleSignInAuthenticator {
+  func decodeNonce(fromJWT jwt: String) -> String? {
+    let segments = jwt.components(separatedBy: ".")
+    guard let parts = decodeJWTSegment(segments[1]),
+          let nonce = parts["nonce"] as? String else {
+      return nil
+    }
+    return nonce
+  }
+
+  func decodeJWTSegment(_ segment: String) -> [String: Any]? {
+    guard let segmentData = base64UrlDecode(segment),
+          let segmentJSON = try? JSONSerialization.jsonObject(with: segmentData, options: []),
+          let payload = segmentJSON as? [String: Any] else {
+      return nil
+    }
+    return payload
+  }
+
+  func base64UrlDecode(_ value: String) -> Data? {
+    var base64 = value
+      .replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+
+    let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+    let requiredLength = 4 * ceil(length / 4.0)
+    let paddingLength = requiredLength - length
+    if paddingLength > 0 {
+      let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+      base64 = base64 + padding
+    }
+    return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+  }
 }

--- a/Samples/Swift/DaysUntilBirthday/Shared/Services/GoogleSignInAuthenticator.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Services/GoogleSignInAuthenticator.swift
@@ -52,7 +52,9 @@ final class GoogleSignInAuthenticator: ObservableObject {
       guard let idToken = signInResult.user.idToken?.tokenString,
             let returnedNonce = self.decodeNonce(fromJWT: idToken),
             returnedNonce == manualNonce else {
-        print("ERROR: Returned nonce doesn't match manual nonce!")
+        // Assert a failure for convenience so that integration tests with thissample app fail upon
+        // `nonce` mismatch
+        assertionFailure("ERROR: Returned nonce doesn't match manual nonce!")
         return
       }
       self.authViewModel.state = .signedIn(signInResult.user)


### PR DESCRIPTION
This PR fixes an issue introduced by #402 related to AppAuth's use of a `nonce`, fixes an issue in GSI's `-[GIDSignIn maybeFetchToken:]`, and provides an example in the DaysUntilBirthday app.

## Issue in #402

https://github.com/google/GoogleSignIn-iOS/pull/402 provides the ability to pass a manual nonce via GSI to AppAuth (e.g., via this [OIDAuthorizationRequest initializer](https://github.com/google/GoogleSignIn-iOS/pull/402) that takes a `nonce` parameter).

Unfortunately, this addition to GSI breaks AppAuth's automatic use of its own `nonce` if one is not supplied since #402 will always pass through [-[GIDSignInOptions nonce]](https://github.com/google/GoogleSignIn-iOS/pull/402/files#diff-b76ad8011382daf05bf7a830db6abe2428c68fbeadd4b617b39bd2c504e2b640R735). So, if the `nonce` in `GIDSignInOptions` is nil, then nil will be passed to AppAuth for the `nonce`, and therefore AppAuth will not produce its own `nonce` via [this initializer](https://github.com/openid/AppAuth-iOS/blob/master/Sources/AppAuthCore/OIDAuthorizationRequest.m#L224).

## Fixing `-[GIDSignIn maybeFetchToken:]`

`-maybeFetchToken` previously used a method on AppAuth (`+[OIDAuthorizationService performTokenRequest:callback:]`) 
that would [pass nil for the last authorization response](https://github.com/openid/AppAuth-iOS/blob/master/Sources/AppAuthCore/OIDAuthorizationService.m#L425). The consequence of this is that the last authorization response's `nonce` will not be available for comparison within AppAuth since the last auth response and its [nonce would be nil](https://github.com/openid/AppAuth-iOS/blob/master/Sources/AppAuthCore/OIDAuthorizationService.m#L641) in the comparison.

This PR fixes the issue by always passing along the last authorization response in `-[GIDSignIn maybeFetchToken:]`.

## DaysUntilBirthdayExample

This PR also provides an example of the client passing in a manual `nonce`, and then comparing the received `nonce` in the authorization response to the manual `nonce`. It provides a simple example that clients may use to develop their own solution for comparing their manual `nonce` to the authorization's returned `nonce`

