### PR TITLE
Remove unification of requested and granted scopes in add scopes flow.

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -283,15 +283,9 @@ static NSString *const kClientAssertionTypeParameterValue =
     }
     return;
   }
-
-  // Use the union of granted and requested scopes.
-  if ([grantedScopes containsObject:kAccountDetailTypeAgeOver18Scope] && grantedScopes.count > 1) {
-    options.scopes = [requestedScopes allObjects];
-  } else {
-    [grantedScopes unionSet:requestedScopes];
-    options.scopes = [grantedScopes allObjects];
-  }
-
+  
+  options.scopes = [requestedScopes allObjects];
+  
   [self signInWithOptions:options];
 }
 

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -284,6 +284,7 @@ static NSString *const kClientAssertionTypeParameterValue =
     return;
   }
   
+  // Previously granted scopes will still be included since we pass `include_granted_scopes=true`.
   options.scopes = [requestedScopes allObjects];
   
   [self signInWithOptions:options];

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -285,8 +285,12 @@ static NSString *const kClientAssertionTypeParameterValue =
   }
 
   // Use the union of granted and requested scopes.
-  [grantedScopes unionSet:requestedScopes];
-  options.scopes = [grantedScopes allObjects];
+  if ([grantedScopes containsObject:kAccountDetailTypeAgeOver18Scope] && grantedScopes.count > 1) {
+    options.scopes = [requestedScopes allObjects];
+  } else {
+    [grantedScopes unionSet:requestedScopes];
+    options.scopes = [grantedScopes allObjects];
+  }
 
   [self signInWithOptions:options];
 }

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -764,8 +764,13 @@ static NSString *const kNewScope = @"newScope";
     [parsedScopes removeObject:@""];
     grantedScopes = [parsedScopes copy];
   }
-  
+
+#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
   NSArray<NSString *> *expectedScopes = @[kNewScope];
+#elif TARGET_OS_OSX
+  NSArray<NSString *> *expectedScopes = @[kNewScope, kGrantedScope];
+#endif // TARGET_OS_OSX
+
   XCTAssertEqualObjects(grantedScopes, expectedScopes);
 
   [_user verify];

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -765,7 +765,7 @@ static NSString *const kNewScope = @"newScope";
     grantedScopes = [parsedScopes copy];
   }
   
-  NSArray<NSString *> *expectedScopes = @[kNewScope, kGrantedScope];
+  NSArray<NSString *> *expectedScopes = @[kNewScope];
   XCTAssertEqualObjects(grantedScopes, expectedScopes);
 
   [_user verify];


### PR DESCRIPTION
With VwG age scope being incorporated, our add scopes flow is running into an "Authorization error: invalid_request". This is happening since `grantedScopes` includes the VwG age scope and is being passed into the request. A solution we'll incorporate is removing the unification to only pass in specified `requestedScopes` into the request.