### PR TITLE
Update iPhone simulator from 14 to 15.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,7 +47,7 @@ jobs:
         fi
 
   swift-button-functional-test:
-    runs-on: macOS-14
+    runs-on: macos-latest
     needs: check-pr-body-for-key
     # Don't run if triggered by a PR from a fork since our Secrets won't be provided to the runner.
     if: ${{ needs.check-pr-body-for-key.outputs.RUN_INTEGRATION == 'yes' && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,7 +47,7 @@ jobs:
         fi
 
   swift-button-functional-test:
-    runs-on: macos-latest
+    runs-on: macOS-14
     needs: check-pr-body-for-key
     # Don't run if triggered by a PR from a fork since our Secrets won't be provided to the runner.
     if: ${{ needs.check-pr-body-for-key.outputs.RUN_INTEGRATION == 'yes' && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
           - sdk: 'macosx'
             destination: '"platform=OS X,arch=x86_64"'
           - sdk: 'iphonesimulator'
-            destination: '"platform=iOS Simulator,name=iPhone 14"'
+            destination: '"platform=iOS Simulator,name=iPhone 15"'
     steps:
     - uses: actions/checkout@v3
     - name: Build unit test target


### PR DESCRIPTION
Recently discovered that iphonesimulator spm-build-test was failing ([example](https://github.com/google/GoogleSignIn-iOS/actions/runs/11826966785/job/32954115329)). This PR updates the simulator from iPhone 14 to 15. 