### PR TITLE
Fix swift button integration test.

### DIFF
--- a/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
+++ b/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
@@ -27,7 +27,7 @@ class DaysUntilBirthdayUITests_iOS: XCTestCase {
   private let appTrustWarningText = "Make sure you trust Days Until Birthday"
   private let chooseAnAccountHeaderText = "Choose an account"
   private let notNowText = "Not Now"
-  private let timeout: TimeInterval = 15
+  private let timeout: TimeInterval = 30
 
   private let sampleApp = XCUIApplication()
   private let springboardApp = XCUIApplication(

--- a/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
+++ b/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
@@ -27,7 +27,7 @@ class DaysUntilBirthdayUITests_iOS: XCTestCase {
   private let appTrustWarningText = "Make sure you trust Days Until Birthday"
   private let chooseAnAccountHeaderText = "Choose an account"
   private let notNowText = "Not Now"
-  private let timeout: TimeInterval = 5
+  private let timeout: TimeInterval = 15
 
   private let sampleApp = XCUIApplication()
   private let springboardApp = XCUIApplication(


### PR DESCRIPTION
GSI's [integration test](https://github.com/google/GoogleSignIn-iOS/issues/367) is failing. I was able to see GitHub's screen recording and the test would fail if a page didn't show up in 5s, but the page will show up eventually (causing the flakiness). To fix this, I've updated `timeout` to 30s to give it enough time.