### PR TITLE
Update runner to macos-13.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-13]
         podspec: [GoogleSignIn.podspec, GoogleSignInSwiftSupport.podspec]
         flag: [
           "",


### PR DESCRIPTION
Noticed that jobs in `unit_tests.yml` are skipped ([ref](https://github.com/google/GoogleSignIn-iOS/actions/runs/11901432966)). Runner `macos-12` has been deprecated according to https://github.com/actions/runner-images/issues/10721 so this PR will update the runner to `macos-13`.

Blocking https://github.com/google/GoogleSignIn-iOS/pull/497. 

SKIP_INTEGRATION_TESTS=YES