### PR TITLE
Fix Swift integration tests for a returning user.

### DIFF
--- a/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
+++ b/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayUITests(iOS)/DaysUntilBirthdayUITests_iOS.swift
@@ -23,6 +23,8 @@ class DaysUntilBirthdayUITests_iOS: XCTestCase {
     "Would you like to save this password to use with apps and websites?"
   private let signInDisclaimerHeaderText =
     "Sign in to Days Until Birthday"
+  private let returningUserSignInDisclaimerHeaderText =
+    "You’re signing back in to Days Until Birthday"
   private let additionalAccessHeaderText = "Days Until Birthday wants additional access to your Google Account"
   private let appTrustWarningText = "Make sure you trust Days Until Birthday"
   private let chooseAnAccountHeaderText = "Choose an account"
@@ -189,7 +191,7 @@ extension DaysUntilBirthdayUITests_iOS {
       return false
     }
 
-    handleSignInDisclaimerIfNeeded()
+    handleReturningUserSignInDisclaimerIfNeeded()
     handleAccessRequestIfNeeded()
 
     return true
@@ -283,6 +285,18 @@ extension DaysUntilBirthdayUITests_iOS {
       .waitForExistence(timeout: timeout)
 
     if currentlyShowingSignInDisclaimer {
+      sampleApp.buttons["Continue"].tap()
+    }
+  }
+
+  func handleReturningUserSignInDisclaimerIfNeeded() {
+    let currentlyShowingReturningUserSignInDisclaimer =
+    sampleApp.staticTexts[returningUserSignInDisclaimerHeaderText]
+      .waitForExistence(timeout: timeout) &&
+    sampleApp.buttons["Continue"]
+      .waitForExistence(timeout: timeout)
+
+    if currentlyShowingReturningUserSignInDisclaimer {
       sampleApp.buttons["Continue"].tap()
     }
   }


### PR DESCRIPTION
One of the web pages have a change in the text. The test is getting "You're signing back in to Days Until Birthday", whereas the text expects "Sign in to Days Until Birthday".