### PR TITLE
Update .gitignore to include .build and Package.resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Podfile.lock
 
 # Firebase App Check Example
 **/GoogleService-Info.plist
+
+# Swift Build
+.build/
+Package.resolved


### PR DESCRIPTION
Updating .gitignore to include .build/ to prevent issues like https://github.com/google/GoogleSignIn-iOS/commit/d3302036c1e6d61345255523734502a8ad936d1d from happening in the future.

Note this aligns with branch briannamorales/vwg-flow: https://github.com/google/GoogleSignIn-iOS/blob/briannamorales/vwg-flow/.gitignore#L24-L25