### PR TITLE
Update GTMAppAuth's URL dependency in Package.swift.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
       from: "11.0.0"),
     .package(
       name: "GTMAppAuth",
-      url: "https://github.com/brnnmrls/GTMAppAuth.git",
+      url: "https://github.com/google/GTMAppAuth.git",
       from: "5.0.0"),
     .package(
       name: "GTMSessionFetcher",


### PR DESCRIPTION
GTMAppAuth's URL was accidentally updated, so this should be reverted back to use the google repo.