### PR TITLE
Update GIDAuthStateMigration to not perform migration when built for Mac Catalyst

### DIFF
--- a/GoogleSignIn/Sources/GIDAuthStateMigration.m
+++ b/GoogleSignIn/Sources/GIDAuthStateMigration.m
@@ -73,7 +73,7 @@ static NSString *const kFingerprintService = @"fingerprint";
     NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
 #if TARGET_OS_OSX
     [defaults setBool:YES forKey:kDataProtectedMigrationCheckPerformedKey];
-#elif TARGET_OS_IOS
+#elif TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     [defaults setBool:YES forKey:kGTMAppAuthMigrationCheckPerformedKey];
 #endif // TARGET_OS_OSX
     return;
@@ -81,7 +81,7 @@ static NSString *const kFingerprintService = @"fingerprint";
 
 #if TARGET_OS_OSX
   [self performDataProtectedMigrationIfNeeded];
-#elif TARGET_OS_IOS
+#elif TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   [self performGIDMigrationIfNeededWithTokenURL:tokenURL
                                    callbackPath:callbackPath
                                    keychainName:keychainName];
@@ -118,7 +118,7 @@ static NSString *const kFingerprintService = @"fingerprint";
   [defaults setBool:YES forKey:kDataProtectedMigrationCheckPerformedKey];
 }
 
-#elif TARGET_OS_IOS
+#elif TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 // Migrate from GPPSignIn 1.x or GIDSignIn 1.0 - 4.x to the GTMAppAuth storage introduced in
 // GIDSignIn 5.0.
 - (void)performGIDMigrationIfNeededWithTokenURL:(NSURL *)tokenURL

--- a/GoogleSignIn/Sources/GIDAuthStateMigration.m
+++ b/GoogleSignIn/Sources/GIDAuthStateMigration.m
@@ -71,24 +71,24 @@ static NSString *const kFingerprintService = @"fingerprint";
   // performed.
   if (isFreshInstall) {
     NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
     [defaults setBool:YES forKey:kDataProtectedMigrationCheckPerformedKey];
 #elif TARGET_OS_IOS
     [defaults setBool:YES forKey:kGTMAppAuthMigrationCheckPerformedKey];
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
     return;
   }
 
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
   [self performDataProtectedMigrationIfNeeded];
 #elif TARGET_OS_IOS
   [self performGIDMigrationIfNeededWithTokenURL:tokenURL
                                    callbackPath:callbackPath
                                    keychainName:keychainName];
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 }
 
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
 // Migrate from the fileBasedKeychain to dataProtectedKeychain with GTMAppAuth 5.0.
 - (void)performDataProtectedMigrationIfNeeded {
   // See if we've performed the migration check previously.
@@ -246,7 +246,7 @@ static NSString *const kFingerprintService = @"fingerprint";
   NSString *password = [[NSString alloc] initWithData:passwordData encoding:NSUTF8StringEncoding];
   return password;
 }
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 
 @end
 

--- a/GoogleSignIn/Tests/Unit/GIDAuthStateMigrationTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDAuthStateMigrationTest.m
@@ -16,9 +16,9 @@
 
 #import "GoogleSignIn/Sources/GIDAuthStateMigration.h"
 #import "GoogleSignIn/Sources/GIDSignInCallbackSchemes.h"
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
 #import "GoogleSignIn/Tests/Unit/OIDAuthState+Testing.h"
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 
 @import GTMAppAuth;
 
@@ -84,9 +84,9 @@ NS_ASSUME_NONNULL_BEGIN
   id _mockNSBundle;
   id _mockGIDSignInCallbackSchemes;
   id _mockGTMOAuth2Compatibility;
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
   id _realLegacyGTMKeychainStore;
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 }
 
 - (void)setUp {
@@ -100,12 +100,12 @@ NS_ASSUME_NONNULL_BEGIN
   _mockNSBundle = OCMStrictClassMock([NSBundle class]);
   _mockGIDSignInCallbackSchemes = OCMStrictClassMock([GIDSignInCallbackSchemes class]);
   _mockGTMOAuth2Compatibility = OCMStrictClassMock([GTMOAuth2Compatibility class]);
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
   GTMKeychainAttribute *fileBasedKeychain = [GTMKeychainAttribute useFileBasedKeychain];
   NSSet *attributes = [NSSet setWithArray:@[fileBasedKeychain]];
   _realLegacyGTMKeychainStore = [[GTMKeychainStore alloc] initWithItemName:kKeychainName
                                                         keychainAttributes:attributes];
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 }
 
 - (void)tearDown {
@@ -125,16 +125,16 @@ NS_ASSUME_NONNULL_BEGIN
   [_mockGIDSignInCallbackSchemes stopMocking];
   [_mockGTMOAuth2Compatibility verify];
   [_mockGTMOAuth2Compatibility stopMocking];
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
   [_realLegacyGTMKeychainStore removeAuthSessionWithError:nil];
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 
   [super tearDown];
 }
 
 #pragma mark - Tests
 
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
 - (void)testMigrateIfNeeded_NoPreviousMigration_DataProtectedMigration {
   [[[_mockUserDefaults stub] andReturn:_mockUserDefaults] standardUserDefaults];
   [[[_mockUserDefaults expect] andReturnValue:@NO] boolForKey:kDataProtectedMigrationCheckPerformedKey];
@@ -242,17 +242,17 @@ NS_ASSUME_NONNULL_BEGIN
 
   XCTAssertNotNil(authorization);
 }
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 
 - (void)testMigrateIfNeeded_HasPreviousMigration {
   [[[_mockUserDefaults stub] andReturn:_mockUserDefaults] standardUserDefaults];
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
   [[[_mockUserDefaults expect] andReturnValue:@YES] boolForKey:kDataProtectedMigrationCheckPerformedKey];
   [[_mockUserDefaults reject] setBool:YES forKey:kDataProtectedMigrationCheckPerformedKey];
 #else
   [[[_mockUserDefaults expect] andReturnValue:@YES] boolForKey:kGTMAppAuthMigrationCheckPerformedKey];
   [[_mockUserDefaults reject] setBool:YES forKey:kGTMAppAuthMigrationCheckPerformedKey];
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 
   GIDAuthStateMigration *migration =
       [[GIDAuthStateMigration alloc] initWithKeychainStore:_mockGTMKeychainStore];
@@ -264,11 +264,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testMigrateIfNeeded_isFreshInstall {
   [[[_mockUserDefaults stub] andReturn:_mockUserDefaults] standardUserDefaults];
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX
   [[_mockUserDefaults expect] setBool:YES forKey:kDataProtectedMigrationCheckPerformedKey];
 #else
   [[_mockUserDefaults expect] setBool:YES forKey:kGTMAppAuthMigrationCheckPerformedKey];
-#endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#endif // TARGET_OS_OSX
 
   GIDAuthStateMigration *migration =
       [[GIDAuthStateMigration alloc] initWithKeychainStore:_mockGTMKeychainStore];

--- a/GoogleSignIn/Tests/Unit/GIDAuthStateMigrationTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDAuthStateMigrationTest.m
@@ -184,7 +184,7 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertNotNil([_realLegacyGTMKeychainStore retrieveAuthSessionWithError:nil]);
 }
 
-#else
+#elif TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)testMigrateIfNeeded_NoPreviousMigration_GTMAppAuthMigration {
   [[[_mockUserDefaults stub] andReturn:_mockUserDefaults] standardUserDefaults];
   [[[_mockUserDefaults expect] andReturnValue:@NO] boolForKey:kGTMAppAuthMigrationCheckPerformedKey];
@@ -249,7 +249,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if TARGET_OS_OSX
   [[[_mockUserDefaults expect] andReturnValue:@YES] boolForKey:kDataProtectedMigrationCheckPerformedKey];
   [[_mockUserDefaults reject] setBool:YES forKey:kDataProtectedMigrationCheckPerformedKey];
-#else
+#elif TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   [[[_mockUserDefaults expect] andReturnValue:@YES] boolForKey:kGTMAppAuthMigrationCheckPerformedKey];
   [[_mockUserDefaults reject] setBool:YES forKey:kGTMAppAuthMigrationCheckPerformedKey];
 #endif // TARGET_OS_OSX
@@ -266,7 +266,7 @@ NS_ASSUME_NONNULL_BEGIN
   [[[_mockUserDefaults stub] andReturn:_mockUserDefaults] standardUserDefaults];
 #if TARGET_OS_OSX
   [[_mockUserDefaults expect] setBool:YES forKey:kDataProtectedMigrationCheckPerformedKey];
-#else
+#elif TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   [[_mockUserDefaults expect] setBool:YES forKey:kGTMAppAuthMigrationCheckPerformedKey];
 #endif // TARGET_OS_OSX
 


### PR DESCRIPTION
In GIDAuthStateMigration we treat TARGET_OS_MACCATALYST as TARGET_OS_OSX however they should be treated the same as TARGET_OS_IOS apps. This PR updates that behavior for GIDAuthStateMigration but does not address other usage of TARGET_OS_MACCATALYST checks throughout the codebase. 