### PR TITLE
Update GIDSignInTest to correctly setUp and tearDown NSUserDefaults

### DIFF
--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -268,10 +268,8 @@ static NSString *const kNewScope = @"newScope";
   // Status returned by saveAuthorization:toKeychainForName:
   BOOL _saveAuthorizationReturnValue;
 
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   // Test userDefaults for use with `GIDAppCheck`
   NSUserDefaults *_testUserDefaults;
-#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 }
 @end
 
@@ -337,14 +335,11 @@ static NSString *const kNewScope = @"newScope";
   [_fakeMainBundle fakeAllSchemesSupported];
 
   // Object under test
-  [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kAppHasRunBeforeKey];
+  _testUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:kUserDefaultsSuiteName];
+  [_testUserDefaults setBool:YES forKey:kAppHasRunBeforeKey];
 
   _signIn = [[GIDSignIn alloc] initWithKeychainStore:_keychainStore];
   _hint = nil;
-
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-  _testUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:kUserDefaultsSuiteName];
-#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
   __weak GIDSignInTest *weakSelf = self;
   _completion = ^(GIDSignInResult *_Nullable signInResult, NSError * _Nullable error) {
@@ -372,11 +367,7 @@ static NSString *const kNewScope = @"newScope";
   OCMVerifyAll(_presentingWindow);
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 
-  [[NSUserDefaults standardUserDefaults] removeObjectForKey:kAppHasRunBeforeKey];
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-  [_testUserDefaults removeObjectForKey:kGIDAppCheckPreparedKey];
-  [_testUserDefaults removeSuiteNamed:kUserDefaultsSuiteName];
-#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+  [_testUserDefaults removePersistentDomainForName:kUserDefaultsSuiteName];
 
   [_fakeMainBundle stopFaking];
   [super tearDown];


### PR DESCRIPTION
NSUserDefaults have not behaving as expected in the GIDSignInTests. Making the GIDSignInTests flaky. Based on my investigation I found the following:
1. We were setting suite name after we wrote to the default suite ([340](https://github.com/google/GoogleSignIn-iOS/blob/main/GoogleSignIn/Tests/Unit/GIDSignInTest.m#L340)) 
2. We were only setting the suite name on iOS ([346](https://github.com/google/GoogleSignIn-iOS/blob/main/GoogleSignIn/Tests/Unit/GIDSignInTest.m#L346))
3. We were not properly cleaning up the NSUserDefaults ([375](https://github.com/google/GoogleSignIn-iOS/blob/main/GoogleSignIn/Tests/Unit/GIDSignInTest.m#L375-L378)). We should be doing [_testUserDefaults removePersistentDomainForName:kUserDefaultsSuiteName] during cleanup
This PR correct the behaviors outlined above. 