### PR TITLE
Updated GIDSignIn + GIDSignInInternalOptions Implementations + Unit Tests

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -28,6 +28,7 @@
 #import "GoogleSignIn/Sources/GIDCallbackQueue.h"
 #import "GoogleSignIn/Sources/GIDScopes.h"
 #import "GoogleSignIn/Sources/GIDSignInCallbackSchemes.h"
+#import "GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.h"
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import <AppCheckCore/GACAppCheckToken.h>
 #import "GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h"
@@ -136,6 +137,9 @@ static NSString *const kIncludeGrantedScopesParameter = @"include_granted_scopes
 static NSString *const kLoginHintParameter = @"login_hint";
 static NSString *const kHostedDomainParameter = @"hd";
 
+// Parameter for requesting the token claims.
+static NSString *const kTokenClaimsParameter = @"claims";
+
 // Parameters for auth and token exchange endpoints using App Attest.
 static NSString *const kClientAssertionParameter = @"client_assertion";
 static NSString *const kClientAssertionTypeParameter = @"client_assertion_type";
@@ -169,6 +173,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   // set when a sign-in flow is begun via |signInWithOptions:| when the options passed don't
   // represent a sign in continuation.
   GIDSignInInternalOptions *_currentOptions;
+  GIDTokenClaimsInternalOptions *_tokenClaimsInternalOptions;
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   GIDAppCheck *_appCheck API_AVAILABLE(ios(14));
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
@@ -284,14 +289,63 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                           additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
                                      nonce:(nullable NSString *)nonce
                                 completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingViewController:presentingViewController
+                                      hint:hint
+                          additionalScopes:additionalScopes
+                                     nonce:nonce
+                               tokenClaims:nil
+                                completion:completion];
+}
+
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingViewController:presentingViewController
+                                      hint:nil
+                               tokenClaims:tokenClaims
+                                completion:completion];
+}
+
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingViewController:presentingViewController
+                                      hint:hint
+                          additionalScopes:@[]
+                               tokenClaims:tokenClaims
+                                completion:completion];
+}
+
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                          additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingViewController:presentingViewController
+                                      hint:hint
+                          additionalScopes:additionalScopes
+                                     nonce:nil
+                               tokenClaims:tokenClaims
+                                completion:completion];
+}
+
+
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                          additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                                     nonce:(nullable NSString *)nonce
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:(nullable GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options =
-    [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
-                                     presentingViewController:presentingViewController
-                                                    loginHint:hint
-                                                addScopesFlow:NO
-                                                       scopes:additionalScopes
-                                                        nonce:nonce
-                                                   completion:completion];
+      [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
+                                       presentingViewController:presentingViewController
+                                                      loginHint:hint
+                                                  addScopesFlow:NO
+                                                         scopes:additionalScopes
+                                                          nonce:nonce
+                                                    tokenClaims:tokenClaims
+                                                     completion:completion];
   [self signInWithOptions:options];
 }
 
@@ -375,14 +429,62 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                   additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
                              nonce:(nullable NSString *)nonce
                         completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingWindow:presentingWindow
+                              hint:hint
+                  additionalScopes:additionalScopes
+                             nonce:nonce
+                       tokenClaims:nil
+                        completion:completion];
+}
+
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingWindow:presentingWindow
+                              hint:nil
+                       tokenClaims:tokenClaims
+                        completion:completion];
+}
+
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingWindow:presentingWindow
+                              hint:hint
+                  additionalScopes:@[]
+                       tokenClaims:tokenClaims
+                        completion:completion];
+}
+
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                  additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingWindow:presentingWindow
+                              hint:hint
+                  additionalScopes:additionalScopes
+                             nonce:nil
+                       tokenClaims:tokenClaims
+                        completion:completion];
+}
+
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                  additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                             nonce:(nullable NSString *)nonce
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options =
-    [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
-                                             presentingWindow:presentingWindow
-                                                    loginHint:hint
-                                                addScopesFlow:NO
-                                                       scopes:additionalScopes
-                                                        nonce:nonce
-                                                   completion:completion];
+      [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
+                                               presentingWindow:presentingWindow
+                                                      loginHint:hint
+                                                  addScopesFlow:NO
+                                                         scopes:additionalScopes
+                                                          nonce:nonce
+                                                    tokenClaims:tokenClaims
+                                                     completion:completion];
   [self signInWithOptions:options];
 }
 
@@ -542,6 +644,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   self = [super init];
   if (self) {
     _keychainStore = keychainStore;
+    _tokenClaimsInternalOptions = [[GIDTokenClaimsInternalOptions alloc] init];
 
     // Get the bundle of the current executable.
     NSBundle *bundle = NSBundle.mainBundle;
@@ -636,6 +739,18 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
       }
     }];
   } else {
+    NSError *claimsError;
+
+    // If tokenClaims are invalid or JSON serialization fails, return with an error.
+    if (![self processTokenClaimsForOptions:options error:&claimsError]) {
+      if (options.completion) {
+        self->_currentOptions = nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+          options.completion(nil, claimsError);
+        });
+      }
+      return;
+    }
     [self authenticateWithOptions:options];
   }
 }
@@ -764,6 +879,9 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   }
   if (options.configuration.hostedDomain) {
     additionalParameters[kHostedDomainParameter] = options.configuration.hostedDomain;
+  }
+  if (options.tokenClaimsAsJSON) {
+    additionalParameters[kTokenClaimsParameter] = options.tokenClaimsAsJSON;
   }
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
@@ -1147,6 +1265,24 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
     [NSException raise:NSInvalidArgumentException
                 format:@"|presentingViewController| must be set."];
   }
+}
+
+- (BOOL)processTokenClaimsForOptions:(GIDSignInInternalOptions *)options
+                               error:(NSError **)error {
+  if (!options.tokenClaims) {
+    return YES; // Success
+  }
+
+  NSString *tokenClaimsAsJSON =
+      [_tokenClaimsInternalOptions validatedJSONStringForClaims:options.tokenClaims
+                                                          error:error];
+
+  if (!tokenClaimsAsJSON) {
+    return NO; // Failure
+  }
+
+  options.tokenClaimsAsJSON = tokenClaimsAsJSON;
+  return YES; // Success
 }
 
 // Checks whether or not this is the first time the app runs.

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.h
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.h
@@ -68,6 +68,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// and to mitigate replay attacks.
 @property(nonatomic, readonly, copy, nullable) NSString *nonce;
 
+/// The tokenClaims requested by the Clients.
+@property(nonatomic, readonly, copy, nullable) NSSet<GIDTokenClaim *> *tokenClaims;
+
+/// The JSON token claims to be used during the flow.
+@property(nonatomic, copy, nullable) NSString *tokenClaimsAsJSON;
+
 /// Creates the default options.
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
@@ -82,6 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
                                           nonce:(nullable NSString *)nonce
+                                    tokenClaims:(nullable NSSet *)tokenClaims
                                      completion:(nullable GIDSignInCompletion)completion;
 
 #elif TARGET_OS_OSX
@@ -97,6 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
                                           nonce:(nullable NSString *)nonce
+                                    tokenClaims:(nullable NSSet *)tokenClaims
                                      completion:(nullable GIDSignInCompletion)completion;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.m
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
                                           nonce:(nullable NSString *)nonce
+                                    tokenClaims:(nullable NSSet *)tokenClaims
                                      completion:(nullable GIDSignInCompletion)completion {
 #elif TARGET_OS_OSX
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
@@ -57,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_completion = completion;
     options->_scopes = [GIDScopes scopesWithBasicProfile:scopes];
     options->_nonce = nonce;
+    options->_tokenClaims = tokenClaims;
   }
   return options;
 }
@@ -84,6 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                 addScopesFlow:addScopesFlow
                                                                        scopes:@[]
                                                                         nonce:nil
+                                                                  tokenClaims:nil
                                                                    completion:completion];
   return options;
 }
@@ -120,6 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_loginHint = _loginHint;
     options->_completion = _completion;
     options->_scopes = _scopes;
+    options->_tokenClaims = _tokenClaims;
     options->_extraParams = [extraParams copy];
   }
   return options;

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -26,6 +26,7 @@
 @class GIDConfiguration;
 @class GIDGoogleUser;
 @class GIDSignInResult;
+@class GIDTokenClaim;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -225,6 +226,99 @@ NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.")
                        NSError *_Nullable error))completion
     NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
+/// Starts an interactive sign-in flow on iOS using the provided tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingViewController The view controller used to present `SFSafariViewController` on
+///     iOS 9 and 10.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:
+    (nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                       NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+
+/// Starts an interactive sign-in flow on iOS using the provided hint, and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingViewController The view controller used to present `SFSafariViewController` on
+///     iOS 9 and 10.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:
+    (nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                       NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+
+/// Starts an interactive sign-in flow on iOS using the provided hint, additional scopes,
+/// and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingViewController The view controller used to present `SFSafariViewController` on
+///     iOS 9 and 10.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                          additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:
+    (nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                       NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+
+/// Starts an interactive sign-in flow on iOS using the provided hint, additional scopes, nonce
+/// and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingViewController The view controller used to present `SFSafariViewController` on
+///     iOS 9 and 10.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
+/// @param nonce A custom nonce.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                          additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                                     nonce:(nullable NSString *)nonce
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:
+    (nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                       NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+
 #elif TARGET_OS_OSX
 
 /// Starts an interactive sign-in flow on macOS.
@@ -298,6 +392,86 @@ NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.")
                         completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
                                                       NSError *_Nullable error))completion;
 
+/// Starts an interactive sign-in flow on macOS using the provided tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                      NSError *_Nullable error))completion;
+
+/// Starts an interactive sign-in flow on macOS using the provided hint, and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                      NSError *_Nullable error))completion;
+
+/// Starts an interactive sign-in flow on macOS using the provided hint, additional scopes
+/// and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                  additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                      NSError *_Nullable error))completion;
+
+/// Starts an interactive sign-in flow on macOS using the provided hint, additional scopes, nonce
+/// and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
+/// @param nonce A custom nonce.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                  additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                             nonce:(nullable NSString *)nonce
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                      NSError *_Nullable error))completion;
 
 #endif
 

--- a/GoogleSignIn/Tests/Unit/GIDSignInInternalOptionsTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInInternalOptionsTest.m
@@ -63,6 +63,56 @@
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 }
 
+- (void)testDefaultOptions_withAllParameters_initializesPropertiesCorrectly {
+  id configuration = OCMStrictClassMock([GIDConfiguration class]);
+#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
+  id presentingViewController = OCMStrictClassMock([UIViewController class]);
+#elif TARGET_OS_OSX
+  id presentingWindow = OCMStrictClassMock([NSWindow class]);
+#endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
+  NSString *loginHint = @"login_hint";
+  NSArray<NSString *> *scopes = @[@"scope1", @"scope2"];
+  NSString *nonce = @"test_nonce";
+  NSSet<GIDTokenClaim *> *tokenClaims = [NSSet setWithObject:[GIDTokenClaim authTimeClaim]];
+
+  // The expected scopes array will contain the provided scopes plus the default profile scopes.
+  NSArray<NSString *> *expectedScopes = @[@"scope1", @"scope2", @"email", @"profile"];
+
+  GIDSignInCompletion completion = ^(GIDSignInResult *_Nullable signInResult,
+                                     NSError * _Nullable error) {};
+  GIDSignInInternalOptions *options =
+      [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
+#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
+                                       presentingViewController:presentingViewController
+#elif TARGET_OS_OSX
+                                               presentingWindow:presentingWindow
+#endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
+                                                      loginHint:loginHint
+                                                  addScopesFlow:NO
+                                                         scopes:scopes
+                                                          nonce:nonce
+                                                    tokenClaims:tokenClaims
+                                                     completion:completion];
+  XCTAssertTrue(options.interactive);
+  XCTAssertFalse(options.continuation);
+  XCTAssertFalse(options.addScopesFlow);
+  XCTAssertNil(options.extraParams);
+
+  // Convert arrays to sets for comparison to make the test order-independent.
+  XCTAssertEqualObjects([NSSet setWithArray:options.scopes], [NSSet setWithArray:expectedScopes]);
+  XCTAssertEqualObjects(options.nonce, nonce);
+  XCTAssertEqualObjects(options.tokenClaims, tokenClaims);
+  XCTAssertNil(options.tokenClaimsAsJSON);
+
+  OCMVerifyAll(configuration);
+#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
+  OCMVerifyAll(presentingViewController);
+#elif TARGET_OS_OSX
+  OCMVerifyAll(presentingWindow);
+#endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
+}
+
+
 - (void)testSilentOptions {
   GIDSignInCompletion completion = ^(GIDSignInResult *_Nullable signInResult,
                                      NSError * _Nullable error) {};

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -8,6 +8,10 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR COhttp://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
@@ -32,6 +36,7 @@
 #import "GoogleSignIn/Sources/GIDGoogleUser_Private.h"
 #import "GoogleSignIn/Sources/GIDSignIn_Private.h"
 #import "GoogleSignIn/Sources/GIDSignInPreferences.h"
+#import "GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.h"
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import <AppCheckCore/GACAppCheckToken.h>
@@ -158,6 +163,12 @@ static NSString *const kEMMSupport = @"1";
 
 static NSString *const kGrantedScope = @"grantedScope";
 static NSString *const kNewScope = @"newScope";
+
+static NSString *const kEssentialAuthTimeClaimsJsonString =
+    @"{\"id_token\":{\"auth_time\":{\"essential\":true}}}";
+static NSString *const kNonEssentialAuthTimeClaimsJsonString =
+    @"{\"id_token\":{\"auth_time\":{\"essential\":false}}}";
+
 
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 // This category is used to allow the test to swizzle a private method.
@@ -517,18 +528,18 @@ static NSString *const kNewScope = @"newScope";
   OCMStub([idTokenDecoded alloc]).andReturn(idTokenDecoded);
   OCMStub([idTokenDecoded initWithIDTokenString:OCMOCK_ANY]).andReturn(idTokenDecoded);
   OCMStub([idTokenDecoded subject]).andReturn(kFakeGaiaID);
-  
+
   // Mock generating a GIDConfiguration when initializing GIDGoogleUser.
   OIDAuthorizationResponse *authResponse =
       [OIDAuthorizationResponse testInstance];
-  
+
   OCMStub([_authState lastAuthorizationResponse]).andReturn(authResponse);
   OCMStub([_tokenResponse idToken]).andReturn(kFakeIDToken);
   OCMStub([_tokenResponse request]).andReturn(_tokenRequest);
   OCMStub([_tokenRequest additionalParameters]).andReturn(nil);
   OCMStub([_tokenResponse accessToken]).andReturn(kAccessToken);
   OCMStub([_tokenResponse accessTokenExpirationDate]).andReturn(nil);
-  
+
   [_signIn restorePreviousSignInNoRefresh];
 
   [idTokenDecoded verify];
@@ -691,12 +702,14 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:nil
             emmPasscodeInfoRequired:NO
                       keychainError:NO
+                   tokenClaimsError:NO
                      restoredSignIn:NO
                      oldAccessToken:NO
                         modalCancel:NO
                 useAdditionalScopes:YES
                    additionalScopes:nil
-                        manualNonce:nil];
+                        manualNonce:nil
+                        tokenClaims:nil];
 
   expectedScopeString = [@[ @"email", @"profile" ] componentsJoinedByString:@" "];
   XCTAssertEqualObjects(_savedAuthorizationRequest.scope, expectedScopeString);
@@ -706,12 +719,14 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:nil
             emmPasscodeInfoRequired:NO
                       keychainError:NO
+                   tokenClaimsError:NO
                      restoredSignIn:NO
                      oldAccessToken:NO
                         modalCancel:NO
                 useAdditionalScopes:YES
                    additionalScopes:@[ kScope ]
-                        manualNonce:nil];
+                        manualNonce:nil
+                        tokenClaims:nil];
 
   expectedScopeString = [@[ kScope, @"email", @"profile" ] componentsJoinedByString:@" "];
   XCTAssertEqualObjects(_savedAuthorizationRequest.scope, expectedScopeString);
@@ -721,15 +736,63 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:nil
             emmPasscodeInfoRequired:NO
                       keychainError:NO
+                   tokenClaimsError:NO
                      restoredSignIn:NO
                      oldAccessToken:NO
                         modalCancel:NO
                 useAdditionalScopes:YES
                    additionalScopes:@[ kScope, kScope2 ]
-                        manualNonce:nil];
+                        manualNonce:nil
+                        tokenClaims:nil];
 
   expectedScopeString = [@[ kScope, kScope2, @"email", @"profile" ] componentsJoinedByString:@" "];
   XCTAssertEqualObjects(_savedAuthorizationRequest.scope, expectedScopeString);
+}
+
+- (void)testOAuthLogin_TokenClaims {
+  GIDTokenClaim *authTimeClaim = [GIDTokenClaim authTimeClaim];
+  GIDTokenClaim *essentialAuthTimeClaim = [GIDTokenClaim essentialAuthTimeClaim];
+
+  OCMStub([_keychainStore saveAuthSession:OCMOCK_ANY error:OCMArg.anyObjectRef]
+          ).andDo(^(NSInvocation *invocation){
+    self->_keychainSaved = self->_saveAuthorizationReturnValue;
+  });
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+                      keychainError:NO
+                   tokenClaimsError:NO
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO
+                useAdditionalScopes:NO
+                   additionalScopes:nil
+                        manualNonce:nil
+                        tokenClaims:[NSSet setWithObject:essentialAuthTimeClaim]];
+
+  XCTAssertEqualObjects(_savedAuthorizationRequest.additionalParameters[@"claims"],
+                        kEssentialAuthTimeClaimsJsonString,
+                        @"Claims JSON should be correctly formatted");
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+                      keychainError:NO
+                   tokenClaimsError:NO
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO
+                useAdditionalScopes:NO
+                   additionalScopes:nil
+                        manualNonce:nil
+                        tokenClaims:[NSSet setWithObject:authTimeClaim]];
+
+  XCTAssertEqualObjects(_savedAuthorizationRequest.additionalParameters[@"claims"],
+                        kNonEssentialAuthTimeClaimsJsonString,
+                        @"Claims JSON should be correctly formatted");
 }
 
 - (void)testAddScopes {
@@ -752,7 +815,7 @@ static NSString *const kNewScope = @"newScope";
 
   id profile = OCMStrictClassMock([GIDProfileData class]);
   OCMStub([profile email]).andReturn(kUserEmail);
-  
+
   // Mock for the method `addScopes`.
   GIDConfiguration *configuration = [[GIDConfiguration alloc] initWithClientID:kClientId
                                                                 serverClientID:nil
@@ -784,7 +847,7 @@ static NSString *const kNewScope = @"newScope";
     [parsedScopes removeObject:@""];
     grantedScopes = [parsedScopes copy];
   }
-  
+
   NSArray<NSString *> *expectedScopes = @[kNewScope, kGrantedScope];
   XCTAssertEqualObjects(grantedScopes, expectedScopes);
 
@@ -831,18 +894,20 @@ static NSString *const kNewScope = @"newScope";
   });
 
   NSString* manualNonce = @"manual_nonce";
-  
+
   [self OAuthLoginWithAddScopesFlow:NO
                           authError:nil
                          tokenError:nil
             emmPasscodeInfoRequired:NO
                       keychainError:NO
+                   tokenClaimsError:NO
                      restoredSignIn:NO
                      oldAccessToken:NO
                         modalCancel:NO
                 useAdditionalScopes:NO
                    additionalScopes:@[]
-                        manualNonce:manualNonce];
+                        manualNonce:manualNonce
+                        tokenClaims:nil];
 
   XCTAssertEqualObjects(_savedAuthorizationRequest.nonce,
                         manualNonce,
@@ -948,6 +1013,36 @@ static NSString *const kNewScope = @"newScope";
   XCTAssertTrue(_completionCalled, @"should call delegate");
   XCTAssertEqualObjects(_authError.domain, kGIDSignInErrorDomain);
   XCTAssertEqual(_authError.code, kGIDSignInErrorCodeKeychain);
+}
+
+- (void)testOAuthLogin_TokenClaims_FailsWithError {
+  GIDTokenClaim *authTimeClaim = [GIDTokenClaim authTimeClaim];
+  GIDTokenClaim *essentialAuthTimeClaim = [GIDTokenClaim essentialAuthTimeClaim];
+  NSSet *conflictingClaims = [NSSet setWithObjects:authTimeClaim, essentialAuthTimeClaim, nil];
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+                      keychainError:NO
+                   tokenClaimsError:YES
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO
+                useAdditionalScopes:NO
+                   additionalScopes:nil
+                        manualNonce:nil
+                        tokenClaims:conflictingClaims];
+
+  // Wait for the completion handler to be called
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  XCTAssertNotNil(_authError, @"An error object should have been returned.");
+  XCTAssertEqual(_authError.code, kGIDSignInErrorCodeAmbiguousClaims,
+                 @"The error code should be for ambiguous claims.");
+  XCTAssertEqualObjects(_authError.domain, kGIDSignInErrorDomain,
+                        @"The error domain should be the GIDSignIn error domain.");
+  XCTAssertEqualObjects(_authError.localizedDescription, kGIDTokenClaimErrorDescription,
+                        @"The error description should clearly explain the ambiguity.");
 }
 
 - (void)testSignOut {
@@ -1339,7 +1434,7 @@ static NSString *const kNewScope = @"newScope";
   NSError *handledError = [NSError errorWithDomain:kGIDSignInErrorDomain
                                               code:kGIDSignInErrorCodeEMM
                                           userInfo:emmError.userInfo];
-  
+
   completion(handledError);
 
   [self waitForExpectationsWithTimeout:1 handler:nil];
@@ -1424,12 +1519,14 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:tokenError
             emmPasscodeInfoRequired:emmPasscodeInfoRequired
                       keychainError:keychainError
+                   tokenClaimsError:NO
                      restoredSignIn:restoredSignIn
                      oldAccessToken:oldAccessToken
                         modalCancel:modalCancel
                 useAdditionalScopes:NO
                    additionalScopes:nil
-                        manualNonce:nil];
+                        manualNonce:nil
+                        tokenClaims:nil];
 }
 
 // The authorization flow with parameters to control which branches to take.
@@ -1438,12 +1535,14 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:(NSError *)tokenError
             emmPasscodeInfoRequired:(BOOL)emmPasscodeInfoRequired
                       keychainError:(BOOL)keychainError
+                   tokenClaimsError:(BOOL)tokenClaimsError
                      restoredSignIn:(BOOL)restoredSignIn
                      oldAccessToken:(BOOL)oldAccessToken
                         modalCancel:(BOOL)modalCancel
                 useAdditionalScopes:(BOOL)useAdditionalScopes
-                   additionalScopes:(NSArray *)additionalScopes 
-                        manualNonce:(NSString *)nonce {
+                   additionalScopes:(NSArray *)additionalScopes
+                        manualNonce:(NSString *)nonce
+                        tokenClaims:(NSSet *)tokenClaims {
   if (restoredSignIn) {
     // clearAndAuthenticateWithOptions
     [[[_authorization expect] andReturn:_authState] authState];
@@ -1533,8 +1632,16 @@ static NSString *const kNewScope = @"newScope";
                                        hint:_hint
                            additionalScopes:nil
                                       nonce:nonce
+                                tokenClaims:tokenClaims
                                  completion:completion];
       }
+    }
+
+    if (tokenClaimsError) {
+      XCTestExpectation *tokenClaimsErrorExpectation =
+          [self expectationWithDescription:@"Callback called"];
+      [tokenClaimsErrorExpectation fulfill];
+      return;
     }
 
     [_authorization verify];
@@ -1631,7 +1738,7 @@ static NSString *const kNewScope = @"newScope";
                                                     profileData:SAVE_TO_ARG_BLOCK(profileData)];
     }
   }
-  
+
   // CompletionCallback - mock server auth code parsing
   if (!keychainError) {
     [[[_authState expect] andReturn:tokenResponse] lastTokenResponse];
@@ -1653,9 +1760,9 @@ static NSString *const kNewScope = @"newScope";
     return;
   }
   [self waitForExpectationsWithTimeout:1 handler:nil];
-  
+
   [_authState verify];
-  
+
   XCTAssertTrue(_keychainSaved, @"should save to keychain");
   if (addScopesFlow) {
     XCTAssertNotNil(updatedTokenResponse);
@@ -1692,7 +1799,7 @@ static NSString *const kNewScope = @"newScope";
   [self waitForExpectationsWithTimeout:1 handler:nil];
   XCTAssertFalse(_keychainRemoved, @"should not remove keychain");
   XCTAssertFalse(_keychainSaved, @"should not save to keychain again");
-  
+
   if (restoredSignIn) {
     // Ignore the return value
     OCMVerify((void)[_keychainStore retrieveAuthSessionWithError:OCMArg.anyObjectRef]);


### PR DESCRIPTION
This pull request updates the existing implementation of `GIDSignIn` class and `GIDSignInInternalOptions` class.

Key changes:

* Updates the `signWith...` initializers to provide public api's to request for tokenClaims.
* Updates `GIDSignInInternalOptions` to store tokenClaims.
* Updates the sign-in flow to include tokenClaims within the `OIDAuthorizationRequest`.
* Provides unit tests to validate the implementation.