### PR TITLE
Ensure `additionalTokenRefreshParametersForAuthSession` returns a string dictionary

### DIFF
--- a/GoogleSignIn/Sources/GIDJSONSerializer/API/GIDJSONSerializer.h
+++ b/GoogleSignIn/Sources/GIDJSONSerializer/API/GIDJSONSerializer.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A protocol for serializing an `NSDictionary` into a JSON string.
+ */
+@protocol GIDJSONSerializer <NSObject>
+
+/**
+ * Serializes the given dictionary into a `JSON` string.
+ *
+ * @param jsonObject The dictionary to be serialized.
+ * @param error A pointer to an `NSError` object to be populated upon failure.
+ * @return A `JSON` string representation of the dictionary, or `nil` if an error occurs.
+ */
+- (nullable NSString *)stringWithJSONObject:(NSDictionary<NSString *, id> *)jsonObject
+                                      error:(NSError *_Nullable *_Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/GIDJSONSerializer/Fake/GIDFakeJSONSerializerImpl.h
+++ b/GoogleSignIn/Sources/GIDJSONSerializer/Fake/GIDFakeJSONSerializerImpl.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleSignIn/Sources/GIDJSONSerializer/API/GIDJSONSerializer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** A fake implementation of `GIDJSONSerializer` for testing purposes. */
+@interface GIDFakeJSONSerializerImpl : NSObject <GIDJSONSerializer>
+
+/**
+ * An error to be returned by `stringWithJSONObject:error:`.
+ *
+ * If this property is set, `stringWithJSONObject:error:` will return `nil` and
+ * populate the error parameter with this error.
+ */
+@property(nonatomic, nullable) NSError *serializationError;
+
+/** The dictionary passed to the serialization method. */
+@property(nonatomic, readonly, nullable) NSDictionary<NSString *, id> *capturedJSONObject;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/GIDJSONSerializer/Fake/GIDFakeJSONSerializerImpl.m
+++ b/GoogleSignIn/Sources/GIDJSONSerializer/Fake/GIDFakeJSONSerializerImpl.m
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleSignIn/Sources/GIDJSONSerializer/Fake/GIDFakeJSONSerializerImpl.h"
+
+#import "GoogleSignIn/Sources/GIDJSONSerializer/Implementation/GIDJSONSerializerImpl.h"
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h"
+
+@implementation GIDFakeJSONSerializerImpl
+
+- (nullable NSString *)stringWithJSONObject:(NSDictionary<NSString *, id> *)jsonObject
+                                      error:(NSError *_Nullable *_Nullable)error {
+  _capturedJSONObject = [jsonObject copy];
+
+  // Check if a serialization error should be simulated.
+  if (self.serializationError) {
+    if (error) {
+      *error = self.serializationError;
+    }
+    return nil;
+  }
+
+  // If not failing, fall back to the real serialization path.
+  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:jsonObject
+                                                 options:0
+                                                   error:error];
+  if (!jsonData) {
+      return nil;
+  }
+  return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+}
+
+@end

--- a/GoogleSignIn/Sources/GIDJSONSerializer/Implementation/GIDJSONSerializerImpl.h
+++ b/GoogleSignIn/Sources/GIDJSONSerializer/Implementation/GIDJSONSerializerImpl.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleSignIn/Sources/GIDJSONSerializer/API/GIDJSONSerializer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const kGIDJSONSerializationErrorDescription;
+
+@interface GIDJSONSerializerImpl : NSObject <GIDJSONSerializer>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/GIDJSONSerializer/Implementation/GIDJSONSerializerImpl.m
+++ b/GoogleSignIn/Sources/GIDJSONSerializer/Implementation/GIDJSONSerializerImpl.m
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleSignIn/Sources/GIDJSONSerializer/Implementation/GIDJSONSerializerImpl.h"
+
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h"
+
+NSString * const kGIDJSONSerializationErrorDescription =
+    @"The provided object could not be serialized to a JSON string.";
+
+@implementation GIDJSONSerializerImpl
+
+- (nullable NSString *)stringWithJSONObject:(NSDictionary<NSString *, id> *)jsonObject
+                                      error:(NSError *_Nullable *_Nullable)error {
+  NSError *serializationError;
+  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:jsonObject
+                                                     options:0
+                                                       error:&serializationError];
+  if (!jsonData) {
+    if (error) {
+      *error = [NSError errorWithDomain:kGIDSignInErrorDomain
+                                   code:kGIDSignInErrorCodeJSONSerializationFailure
+                               userInfo:@{
+                            NSLocalizedDescriptionKey:kGIDJSONSerializationErrorDescription,
+                                 NSUnderlyingErrorKey:serializationError
+                               }];
+    }
+    return nil;
+  }
+  return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+}
+
+@end

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -28,6 +28,7 @@
 #import "GoogleSignIn/Sources/GIDCallbackQueue.h"
 #import "GoogleSignIn/Sources/GIDScopes.h"
 #import "GoogleSignIn/Sources/GIDSignInCallbackSchemes.h"
+#import "GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.h"
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import <AppCheckCore/GACAppCheckToken.h>
 #import "GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h"
@@ -136,6 +137,9 @@ static NSString *const kIncludeGrantedScopesParameter = @"include_granted_scopes
 static NSString *const kLoginHintParameter = @"login_hint";
 static NSString *const kHostedDomainParameter = @"hd";
 
+// Parameter for requesting the token claims.
+static NSString *const kTokenClaimsParameter = @"claims";
+
 // Parameters for auth and token exchange endpoints using App Attest.
 static NSString *const kClientAssertionParameter = @"client_assertion";
 static NSString *const kClientAssertionTypeParameter = @"client_assertion_type";
@@ -169,6 +173,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   // set when a sign-in flow is begun via |signInWithOptions:| when the options passed don't
   // represent a sign in continuation.
   GIDSignInInternalOptions *_currentOptions;
+  GIDTokenClaimsInternalOptions *_tokenClaimsInternalOptions;
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   GIDAppCheck *_appCheck API_AVAILABLE(ios(14));
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
@@ -284,14 +289,63 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                           additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
                                      nonce:(nullable NSString *)nonce
                                 completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingViewController:presentingViewController
+                                      hint:hint
+                          additionalScopes:additionalScopes
+                                     nonce:nonce
+                               tokenClaims:nil
+                                completion:completion];
+}
+
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingViewController:presentingViewController
+                                      hint:nil
+                               tokenClaims:tokenClaims
+                                completion:completion];
+}
+
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingViewController:presentingViewController
+                                      hint:hint
+                          additionalScopes:@[]
+                               tokenClaims:tokenClaims
+                                completion:completion];
+}
+
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                          additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingViewController:presentingViewController
+                                      hint:hint
+                          additionalScopes:additionalScopes
+                                     nonce:nil
+                               tokenClaims:tokenClaims
+                                completion:completion];
+}
+
+
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                          additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                                     nonce:(nullable NSString *)nonce
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:(nullable GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options =
-    [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
-                                     presentingViewController:presentingViewController
-                                                    loginHint:hint
-                                                addScopesFlow:NO
-                                                       scopes:additionalScopes
-                                                        nonce:nonce
-                                                   completion:completion];
+      [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
+                                       presentingViewController:presentingViewController
+                                                      loginHint:hint
+                                                  addScopesFlow:NO
+                                                         scopes:additionalScopes
+                                                          nonce:nonce
+                                                    tokenClaims:tokenClaims
+                                                     completion:completion];
   [self signInWithOptions:options];
 }
 
@@ -375,14 +429,62 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                   additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
                              nonce:(nullable NSString *)nonce
                         completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingWindow:presentingWindow
+                              hint:hint
+                  additionalScopes:additionalScopes
+                             nonce:nonce
+                       tokenClaims:nil
+                        completion:completion];
+}
+
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingWindow:presentingWindow
+                              hint:nil
+                       tokenClaims:tokenClaims
+                        completion:completion];
+}
+
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingWindow:presentingWindow
+                              hint:hint
+                  additionalScopes:@[]
+                       tokenClaims:tokenClaims
+                        completion:completion];
+}
+
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                  additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable GIDSignInCompletion)completion {
+  [self signInWithPresentingWindow:presentingWindow
+                              hint:hint
+                  additionalScopes:additionalScopes
+                             nonce:nil
+                       tokenClaims:tokenClaims
+                        completion:completion];
+}
+
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                  additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                             nonce:(nullable NSString *)nonce
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable GIDSignInCompletion)completion {
   GIDSignInInternalOptions *options =
-    [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
-                                             presentingWindow:presentingWindow
-                                                    loginHint:hint
-                                                addScopesFlow:NO
-                                                       scopes:additionalScopes
-                                                        nonce:nonce
-                                                   completion:completion];
+      [GIDSignInInternalOptions defaultOptionsWithConfiguration:_configuration
+                                               presentingWindow:presentingWindow
+                                                      loginHint:hint
+                                                  addScopesFlow:NO
+                                                         scopes:additionalScopes
+                                                          nonce:nonce
+                                                    tokenClaims:tokenClaims
+                                                     completion:completion];
   [self signInWithOptions:options];
 }
 
@@ -542,6 +644,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   self = [super init];
   if (self) {
     _keychainStore = keychainStore;
+    _tokenClaimsInternalOptions = [[GIDTokenClaimsInternalOptions alloc] init];
 
     // Get the bundle of the current executable.
     NSBundle *bundle = NSBundle.mainBundle;
@@ -636,6 +739,21 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
       }
     }];
   } else {
+    NSError *claimsError;
+
+    // If tokenClaims are invalid or JSON serialization fails, return with an error.
+    options.tokenClaimsAsJSON = [_tokenClaimsInternalOptions
+                                    validatedJSONStringForClaims:options.tokenClaims
+                                                           error:&claimsError];
+    if (claimsError) {
+      if (options.completion) {
+        self->_currentOptions = nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+          options.completion(nil, claimsError);
+        });
+      }
+      return;
+    }
     [self authenticateWithOptions:options];
   }
 }
@@ -764,6 +882,9 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   }
   if (options.configuration.hostedDomain) {
     additionalParameters[kHostedDomainParameter] = options.configuration.hostedDomain;
+  }
+  if (options.tokenClaimsAsJSON) {
+    additionalParameters[kTokenClaimsParameter] = options.tokenClaimsAsJSON;
   }
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -367,6 +367,14 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                                                   addScopesFlow:YES
                                                      completion:completion];
 
+  OIDAuthorizationRequest *lastAuthorizationRequest =
+      self.currentUser.authState.lastAuthorizationResponse.request;
+  NSString *lastTokenClaimsAsJSON =
+      lastAuthorizationRequest.additionalParameters[kTokenClaimsParameter];
+  if (lastTokenClaimsAsJSON) {
+    options.tokenClaimsAsJSON = lastTokenClaimsAsJSON;
+  }
+
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
       [NSMutableSet setWithArray:self.currentUser.grantedScopes];
@@ -498,6 +506,14 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                                                       loginHint:self.currentUser.profile.email
                                                   addScopesFlow:YES
                                                      completion:completion];
+
+  OIDAuthorizationRequest *lastAuthorizationRequest =
+      self.currentUser.authState.lastAuthorizationResponse.request;
+  NSString *lastTokenClaimsAsJSON =
+      lastAuthorizationRequest.additionalParameters[kTokenClaimsParameter];
+  if (lastTokenClaimsAsJSON) {
+    options.tokenClaimsAsJSON = lastTokenClaimsAsJSON;
+  }
 
   NSSet<NSString *> *requestedScopes = [NSSet setWithArray:scopes];
   NSMutableSet<NSString *> *grantedScopes =
@@ -739,20 +755,23 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
       }
     }];
   } else {
-    NSError *claimsError;
+    // Only serialize tokenClaims if options.tokenClaimsAsJSON isn't already set.
+    if (!options.tokenClaimsAsJSON) {
+      NSError *claimsError;
 
-    // If tokenClaims are invalid or JSON serialization fails, return with an error.
-    options.tokenClaimsAsJSON = [_tokenClaimsInternalOptions
-                                    validatedJSONStringForClaims:options.tokenClaims
-                                                           error:&claimsError];
-    if (claimsError) {
-      if (options.completion) {
-        self->_currentOptions = nil;
-        dispatch_async(dispatch_get_main_queue(), ^{
-          options.completion(nil, claimsError);
-        });
+      // If tokenClaims are invalid or JSON serialization fails, return with an error.
+      options.tokenClaimsAsJSON = [_tokenClaimsInternalOptions
+                                   validatedJSONStringForClaims:options.tokenClaims
+                                                          error:&claimsError];
+      if (claimsError) {
+        if (options.completion) {
+          _currentOptions = nil;
+          dispatch_async(dispatch_get_main_queue(), ^{
+            options.completion(nil, claimsError);
+          });
+        }
+        return;
       }
-      return;
     }
     [self authenticateWithOptions:options];
   }

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.h
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.h
@@ -68,6 +68,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// and to mitigate replay attacks.
 @property(nonatomic, readonly, copy, nullable) NSString *nonce;
 
+/// The tokenClaims requested by the Clients.
+@property(nonatomic, readonly, copy, nullable) NSSet<GIDTokenClaim *> *tokenClaims;
+
+/// The JSON token claims to be used during the flow.
+@property(nonatomic, copy, nullable) NSString *tokenClaimsAsJSON;
+
 /// Creates the default options.
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
@@ -82,6 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
                                           nonce:(nullable NSString *)nonce
+                                    tokenClaims:(nullable NSSet *)tokenClaims
                                      completion:(nullable GIDSignInCompletion)completion;
 
 #elif TARGET_OS_OSX
@@ -97,6 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
                                           nonce:(nullable NSString *)nonce
+                                    tokenClaims:(nullable NSSet *)tokenClaims
                                      completion:(nullable GIDSignInCompletion)completion;
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
 

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.m
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
                                           nonce:(nullable NSString *)nonce
+                                    tokenClaims:(nullable NSSet *)tokenClaims
                                      completion:(nullable GIDSignInCompletion)completion {
 #elif TARGET_OS_OSX
 + (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
@@ -40,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   addScopesFlow:(BOOL)addScopesFlow
                                          scopes:(nullable NSArray *)scopes
                                           nonce:(nullable NSString *)nonce
+                                    tokenClaims:(nullable NSSet *)tokenClaims
                                      completion:(nullable GIDSignInCompletion)completion {
 #endif // TARGET_OS_IOS || TARGET_OS_MACCATALYST
   GIDSignInInternalOptions *options = [[GIDSignInInternalOptions alloc] init];
@@ -57,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_completion = completion;
     options->_scopes = [GIDScopes scopesWithBasicProfile:scopes];
     options->_nonce = nonce;
+    options->_tokenClaims = tokenClaims;
   }
   return options;
 }
@@ -84,6 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                 addScopesFlow:addScopesFlow
                                                                        scopes:@[]
                                                                         nonce:nil
+                                                                  tokenClaims:nil
                                                                    completion:completion];
   return options;
 }
@@ -120,6 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_loginHint = _loginHint;
     options->_completion = _completion;
     options->_scopes = _scopes;
+    options->_tokenClaims = _tokenClaims;
     options->_extraParams = [extraParams copy];
   }
   return options;

--- a/GoogleSignIn/Sources/GIDTokenClaim.m
+++ b/GoogleSignIn/Sources/GIDTokenClaim.m
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDTokenClaim.h"
+
+NSString * const kAuthTimeClaimName = @"auth_time";
+
+// Private interface to declare the internal initializer
+@interface GIDTokenClaim ()
+
+- (instancetype)initWithName:(NSString *)name
+                   essential:(BOOL)essential NS_DESIGNATED_INITIALIZER;
+
+@end
+
+@implementation GIDTokenClaim
+
+// Private designated initializer
+- (instancetype)initWithName:(NSString *)name essential:(BOOL)essential {
+  self = [super init];
+  if (self) {
+    _name = [name copy];
+    _essential = essential;
+  }
+  return self;
+}
+
+#pragma mark - Factory Methods
+
++ (instancetype)authTimeClaim {
+  return [[self alloc] initWithName:kAuthTimeClaimName essential:NO];
+}
+
++ (instancetype)essentialAuthTimeClaim {
+  return [[self alloc] initWithName:kAuthTimeClaimName essential:YES];
+}
+
+#pragma mark - NSObject
+
+- (BOOL)isEqual:(id)object {
+  // 1. Check if the other object is the same instance in memory.
+  if (self == object) {
+    return YES;
+  }
+
+  // 2. Check if the other object is not a GIDTokenClaim instance.
+  if (![object isKindOfClass:[GIDTokenClaim class]]) {
+    return NO;
+  }
+
+  // 3. Compare the properties that define equality.
+  GIDTokenClaim *other = (GIDTokenClaim *)object;
+  return [self.name isEqualToString:other.name] &&
+         self.isEssential == other.isEssential;
+}
+
+- (NSUInteger)hash {
+  // The hash value should be based on the same properties used in isEqual:
+  return self.name.hash ^ @(self.isEssential).hash;
+}
+
+@end

--- a/GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.h
+++ b/GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class GIDTokenClaim;
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const kGIDTokenClaimErrorDescription;
+extern NSString *const kGIDTokenClaimEssentialPropertyKeyName;
+extern NSString *const kGIDTokenClaimKeyName;
+
+@protocol GIDJSONSerializer;
+
+/**
+ * An internal utility class for processing and serializing the `NSSet` of `GIDTokenClaim` objects
+ * into the `JSON` format required for an `OIDAuthorizationRequest`.
+ */
+@interface GIDTokenClaimsInternalOptions : NSObject
+
+- (instancetype)init;
+
+- (instancetype)initWithJSONSerializer:
+    (id<GIDJSONSerializer>)jsonSerializer NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Processes the `NSSet` of `GIDTokenClaim` objects, handling ambiguous claims,
+ * and returns a `JSON` string.
+ *
+ * @param claims The `NSSet` of `GIDTokenClaim` objects provided by the developer.
+ * @param error A pointer to an `NSError` object to be populated if an error occurs (e.g., if a
+ * claim is requested as both essential and non-essential).
+ * @return A `JSON` string representing the claims request, or `nil` if the input is empty or an
+ * error occurs.
+ */
+- (nullable NSString *)validatedJSONStringForClaims:(nullable NSSet<GIDTokenClaim *> *)claims
+                                              error:(NSError *_Nullable *_Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.m
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.h"
+
+#import "GoogleSignIn/Sources/GIDJSONSerializer/API/GIDJSONSerializer.h"
+#import "GoogleSignIn/Sources/GIDJSONSerializer/Implementation/GIDJSONSerializerImpl.h"
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h"
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDTokenClaim.h"
+
+NSString * const kGIDTokenClaimErrorDescription =
+    @"The claim was requested as both essential and non-essential. "
+    @"Please provide only one version.";
+NSString * const kGIDTokenClaimEssentialPropertyKey = @"essential";
+NSString * const kGIDTokenClaimKeyName = @"id_token";
+
+@interface GIDTokenClaimsInternalOptions ()
+@property(nonatomic, readonly) id<GIDJSONSerializer> jsonSerializer;
+@end
+
+@implementation GIDTokenClaimsInternalOptions
+
+- (instancetype)init {
+  return [self initWithJSONSerializer:[[GIDJSONSerializerImpl alloc] init]];
+}
+
+- (instancetype)initWithJSONSerializer:(id<GIDJSONSerializer>)jsonSerializer {
+  if (self = [super init]) {
+    _jsonSerializer = jsonSerializer;
+  }
+  return self;
+}
+
+- (nullable NSString *)validatedJSONStringForClaims:(nullable NSSet<GIDTokenClaim *> *)claims
+                                              error:(NSError *_Nullable *_Nullable)error {
+  if (!claims || claims.count == 0) {
+    return nil;
+  }
+
+  // === Step 1: Check for claims with ambiguous essential property. ===
+  NSMutableDictionary<NSString *, GIDTokenClaim *> *validTokenClaims =
+    [[NSMutableDictionary alloc] init];
+
+  for (GIDTokenClaim *currentClaim in claims) {
+    GIDTokenClaim *existingClaim = validTokenClaims[currentClaim.name];
+
+    // Check for a conflict: a claim with the same name but different essentiality.
+    if (existingClaim && existingClaim.isEssential != currentClaim.isEssential) {
+      if (error) {
+        *error = [NSError errorWithDomain:kGIDSignInErrorDomain
+                                     code:kGIDSignInErrorCodeAmbiguousClaims
+                                 userInfo:@{
+                                   NSLocalizedDescriptionKey:kGIDTokenClaimErrorDescription
+                                 }];
+      }
+      return nil;
+    }
+    validTokenClaims[currentClaim.name] = currentClaim;
+  }
+
+  // === Step 2: Build the dictionary structure required for OIDC JSON ===
+  NSMutableDictionary<NSString *, NSDictionary *> *tokenClaimsDictionary =
+    [[NSMutableDictionary alloc] init];
+  for (GIDTokenClaim *claim in validTokenClaims.allValues) {
+    if (claim.isEssential) {
+      tokenClaimsDictionary[claim.name] = @{ kGIDTokenClaimEssentialPropertyKey: @YES };
+    } else {
+      tokenClaimsDictionary[claim.name] = @{ kGIDTokenClaimEssentialPropertyKey: @NO };
+    }
+  }
+  NSDictionary<NSString *, id> *finalRequestDictionary =
+    @{ kGIDTokenClaimKeyName: tokenClaimsDictionary };
+
+  // === Step 3: Serialize the final dictionary into a JSON string ===
+  return [_jsonSerializer stringWithJSONObject:finalRequestDictionary error:error];
+}
+
+@end

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -45,10 +45,14 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
   kGIDSignInErrorCodeCanceled = -5,
   /// Indicates an Enterprise Mobility Management related error has occurred.
   kGIDSignInErrorCodeEMM = -6,
+  /// Indicates a claim was requested as both essential and non-essential .
+  kGIDSignInErrorCodeAmbiguousClaims = -7,
   /// Indicates the requested scopes have already been granted to the `currentUser`.
   kGIDSignInErrorCodeScopesAlreadyGranted = -8,
   /// Indicates there is an operation on a previous user.
   kGIDSignInErrorCodeMismatchWithCurrentUser = -9,
+  /// Indicates that an object could not be serialized into a `JSON` string.
+  kGIDSignInErrorCodeJSONSerializationFailure = -10
 };
 
 /// This class is used to sign in users with their Google account and manage their session.

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -26,6 +26,7 @@
 @class GIDConfiguration;
 @class GIDGoogleUser;
 @class GIDSignInResult;
+@class GIDTokenClaim;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -225,6 +226,95 @@ NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.")
                        NSError *_Nullable error))completion
     NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
 
+/// Starts an interactive sign-in flow on iOS using the provided tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingViewController The view controller used to present the authorization flow.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:
+    (nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                       NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+
+/// Starts an interactive sign-in flow on iOS using the provided hint and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingViewController The view controller used to present the authorization flow.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:
+    (nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                       NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+
+/// Starts an interactive sign-in flow on iOS using the provided hint, additional scopes,
+/// and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingViewController The view controller used to present the authorization flow.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                          additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:
+    (nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                       NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+
+/// Starts an interactive sign-in flow on iOS using the provided hint, additional scopes, nonce,
+/// and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingViewController The view controller used to present the authorization flow.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
+/// @param nonce A custom nonce.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingViewController:(UIViewController *)presentingViewController
+                                      hint:(nullable NSString *)hint
+                          additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                                     nonce:(nullable NSString *)nonce
+                               tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                                completion:
+    (nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                       NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.");
+
 #elif TARGET_OS_OSX
 
 /// Starts an interactive sign-in flow on macOS.
@@ -298,6 +388,86 @@ NS_EXTENSION_UNAVAILABLE("The sign-in flow is not supported in App Extensions.")
                         completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
                                                       NSError *_Nullable error))completion;
 
+/// Starts an interactive sign-in flow on macOS using the provided tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                      NSError *_Nullable error))completion;
+
+/// Starts an interactive sign-in flow on macOS using the provided hint and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                      NSError *_Nullable error))completion;
+
+/// Starts an interactive sign-in flow on macOS using the provided hint, additional scopes,
+/// and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                  additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                      NSError *_Nullable error))completion;
+
+/// Starts an interactive sign-in flow on macOS using the provided hint, additional scopes, nonce,
+/// and tokenClaims.
+///
+/// The completion will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCompletion:` method to restore a previous sign-in.
+///
+/// @param presentingWindow The window used to supply `presentationContextProvider` for `ASWebAuthenticationSession`.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param additionalScopes An optional array of scopes to request in addition to the basic profile scopes.
+/// @param nonce A custom nonce.
+/// @param tokenClaims An optional `NSSet` of tokenClaims to request.
+/// @param completion The optional block that is called on completion.  This block will
+///     be called asynchronously on the main queue.
+- (void)signInWithPresentingWindow:(NSWindow *)presentingWindow
+                              hint:(nullable NSString *)hint
+                  additionalScopes:(nullable NSArray<NSString *> *)additionalScopes
+                             nonce:(nullable NSString *)nonce
+                       tokenClaims:(nullable NSSet<GIDTokenClaim *> *)tokenClaims
+                        completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                      NSError *_Nullable error))completion;
 
 #endif
 

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDTokenClaim.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDTokenClaim.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const kAuthTimeClaimName;
+
+/**
+ * An object representing a single OIDC claim to be requested for an ID token.
+ */
+@interface GIDTokenClaim : NSObject
+
+/// The name of the claim, e.g., "auth_time".
+@property (nonatomic, readonly) NSString *name;
+
+/// Whether the claim is requested as essential.
+@property (nonatomic, readonly, getter=isEssential) BOOL essential;
+
+// Making initializers unavailable to force use of factory methods.
+- (instancetype)init NS_UNAVAILABLE;
+
+#pragma mark - Factory Methods
+
+/// Creates a *non-essential* (voluntary) "auth_time" claim object.
++ (instancetype)authTimeClaim;
+
+/// Creates an *essential* "auth_time" claim object.
++ (instancetype)essentialAuthTimeClaim;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GoogleSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GoogleSignIn.h
@@ -24,6 +24,7 @@
 #import "GIDSignIn.h"
 #import "GIDToken.h"
 #import "GIDSignInResult.h"
+#import "GIDTokenClaim.h"
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 #import "GIDSignInButton.h"
 #endif

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -32,6 +32,7 @@
 #import "GoogleSignIn/Sources/GIDGoogleUser_Private.h"
 #import "GoogleSignIn/Sources/GIDSignIn_Private.h"
 #import "GoogleSignIn/Sources/GIDSignInPreferences.h"
+#import "GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.h"
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import <AppCheckCore/GACAppCheckToken.h>
@@ -158,6 +159,12 @@ static NSString *const kEMMSupport = @"1";
 
 static NSString *const kGrantedScope = @"grantedScope";
 static NSString *const kNewScope = @"newScope";
+
+static NSString *const kEssentialAuthTimeClaimsJsonString =
+    @"{\"id_token\":{\"auth_time\":{\"essential\":true}}}";
+static NSString *const kNonEssentialAuthTimeClaimsJsonString =
+    @"{\"id_token\":{\"auth_time\":{\"essential\":false}}}";
+
 
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 // This category is used to allow the test to swizzle a private method.
@@ -517,18 +524,18 @@ static NSString *const kNewScope = @"newScope";
   OCMStub([idTokenDecoded alloc]).andReturn(idTokenDecoded);
   OCMStub([idTokenDecoded initWithIDTokenString:OCMOCK_ANY]).andReturn(idTokenDecoded);
   OCMStub([idTokenDecoded subject]).andReturn(kFakeGaiaID);
-  
+
   // Mock generating a GIDConfiguration when initializing GIDGoogleUser.
   OIDAuthorizationResponse *authResponse =
       [OIDAuthorizationResponse testInstance];
-  
+
   OCMStub([_authState lastAuthorizationResponse]).andReturn(authResponse);
   OCMStub([_tokenResponse idToken]).andReturn(kFakeIDToken);
   OCMStub([_tokenResponse request]).andReturn(_tokenRequest);
   OCMStub([_tokenRequest additionalParameters]).andReturn(nil);
   OCMStub([_tokenResponse accessToken]).andReturn(kAccessToken);
   OCMStub([_tokenResponse accessTokenExpirationDate]).andReturn(nil);
-  
+
   [_signIn restorePreviousSignInNoRefresh];
 
   [idTokenDecoded verify];
@@ -691,12 +698,14 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:nil
             emmPasscodeInfoRequired:NO
                       keychainError:NO
+                   tokenClaimsError:NO
                      restoredSignIn:NO
                      oldAccessToken:NO
                         modalCancel:NO
                 useAdditionalScopes:YES
                    additionalScopes:nil
-                        manualNonce:nil];
+                        manualNonce:nil
+                        tokenClaims:nil];
 
   expectedScopeString = [@[ @"email", @"profile" ] componentsJoinedByString:@" "];
   XCTAssertEqualObjects(_savedAuthorizationRequest.scope, expectedScopeString);
@@ -706,12 +715,14 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:nil
             emmPasscodeInfoRequired:NO
                       keychainError:NO
+                   tokenClaimsError:NO
                      restoredSignIn:NO
                      oldAccessToken:NO
                         modalCancel:NO
                 useAdditionalScopes:YES
                    additionalScopes:@[ kScope ]
-                        manualNonce:nil];
+                        manualNonce:nil
+                        tokenClaims:nil];
 
   expectedScopeString = [@[ kScope, @"email", @"profile" ] componentsJoinedByString:@" "];
   XCTAssertEqualObjects(_savedAuthorizationRequest.scope, expectedScopeString);
@@ -721,15 +732,99 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:nil
             emmPasscodeInfoRequired:NO
                       keychainError:NO
+                   tokenClaimsError:NO
                      restoredSignIn:NO
                      oldAccessToken:NO
                         modalCancel:NO
                 useAdditionalScopes:YES
                    additionalScopes:@[ kScope, kScope2 ]
-                        manualNonce:nil];
+                        manualNonce:nil
+                        tokenClaims:nil];
 
   expectedScopeString = [@[ kScope, kScope2, @"email", @"profile" ] componentsJoinedByString:@" "];
   XCTAssertEqualObjects(_savedAuthorizationRequest.scope, expectedScopeString);
+}
+
+- (void)testOAuthLogin_WithTokenClaims_FormatsParametersCorrectly {
+  GIDTokenClaim *authTimeClaim = [GIDTokenClaim authTimeClaim];
+  GIDTokenClaim *essentialAuthTimeClaim = [GIDTokenClaim essentialAuthTimeClaim];
+
+  OCMStub([_keychainStore saveAuthSession:OCMOCK_ANY error:OCMArg.anyObjectRef]
+          ).andDo(^(NSInvocation *invocation){
+    self->_keychainSaved = self->_saveAuthorizationReturnValue;
+  });
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+                      keychainError:NO
+                   tokenClaimsError:NO
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO
+                useAdditionalScopes:NO
+                   additionalScopes:nil
+                        manualNonce:nil
+                        tokenClaims:[NSSet setWithObject:essentialAuthTimeClaim]];
+
+  XCTAssertEqualObjects(_savedAuthorizationRequest.additionalParameters[@"claims"],
+                        kEssentialAuthTimeClaimsJsonString,
+                        @"Claims JSON should be correctly formatted");
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+                      keychainError:NO
+                   tokenClaimsError:NO
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO
+                useAdditionalScopes:NO
+                   additionalScopes:nil
+                        manualNonce:nil
+                        tokenClaims:[NSSet setWithObject:authTimeClaim]];
+
+  XCTAssertEqualObjects(_savedAuthorizationRequest.additionalParameters[@"claims"],
+                        kNonEssentialAuthTimeClaimsJsonString,
+                        @"Claims JSON should be correctly formatted");
+}
+
+- (void)testOAuthLogin_WithTokenClaims_ReturnsIdTokenWithCorrectClaims {
+  GIDTokenClaim *authTimeClaim = [GIDTokenClaim authTimeClaim];
+
+  OCMStub([_keychainStore saveAuthSession:OCMOCK_ANY error:OCMArg.anyObjectRef]
+          ).andDo(^(NSInvocation *invocation){
+    self->_keychainSaved = self->_saveAuthorizationReturnValue;
+  });
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+                      keychainError:NO
+                   tokenClaimsError:NO
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO
+                useAdditionalScopes:NO
+                   additionalScopes:nil
+                        manualNonce:nil
+                        tokenClaims:[NSSet setWithObject:authTimeClaim]];
+
+  XCTAssertNotNil(_signIn.currentUser, @"The currentUser should not be nil after a successful sign-in.");
+  NSString *idTokenString = _signIn.currentUser.idToken.tokenString;
+  XCTAssertNotNil(idTokenString, @"ID token string should not be nil.");
+  NSArray<NSString *> *components = [idTokenString componentsSeparatedByString:@"."];
+  XCTAssertEqual(components.count, 3, @"JWT should have 3 parts.");
+  NSData *payloadData = [[NSData alloc]
+      initWithBase64EncodedString:components[1]
+                          options:NSDataBase64DecodingIgnoreUnknownCharacters];
+  NSDictionary *claims = [NSJSONSerialization JSONObjectWithData:payloadData options:0 error:nil];
+  XCTAssertEqualObjects(claims[@"auth_time"],
+                        kAuthTime,
+                        @"The 'auth_time' claim should be present and correct.");
 }
 
 - (void)testAddScopes {
@@ -752,7 +847,7 @@ static NSString *const kNewScope = @"newScope";
 
   id profile = OCMStrictClassMock([GIDProfileData class]);
   OCMStub([profile email]).andReturn(kUserEmail);
-  
+
   // Mock for the method `addScopes`.
   GIDConfiguration *configuration = [[GIDConfiguration alloc] initWithClientID:kClientId
                                                                 serverClientID:nil
@@ -784,7 +879,7 @@ static NSString *const kNewScope = @"newScope";
     [parsedScopes removeObject:@""];
     grantedScopes = [parsedScopes copy];
   }
-  
+
   NSArray<NSString *> *expectedScopes = @[kNewScope, kGrantedScope];
   XCTAssertEqualObjects(grantedScopes, expectedScopes);
 
@@ -831,18 +926,20 @@ static NSString *const kNewScope = @"newScope";
   });
 
   NSString* manualNonce = @"manual_nonce";
-  
+
   [self OAuthLoginWithAddScopesFlow:NO
                           authError:nil
                          tokenError:nil
             emmPasscodeInfoRequired:NO
                       keychainError:NO
+                   tokenClaimsError:NO
                      restoredSignIn:NO
                      oldAccessToken:NO
                         modalCancel:NO
                 useAdditionalScopes:NO
                    additionalScopes:@[]
-                        manualNonce:manualNonce];
+                        manualNonce:manualNonce
+                        tokenClaims:nil];
 
   XCTAssertEqualObjects(_savedAuthorizationRequest.nonce,
                         manualNonce,
@@ -948,6 +1045,36 @@ static NSString *const kNewScope = @"newScope";
   XCTAssertTrue(_completionCalled, @"should call delegate");
   XCTAssertEqualObjects(_authError.domain, kGIDSignInErrorDomain);
   XCTAssertEqual(_authError.code, kGIDSignInErrorCodeKeychain);
+}
+
+- (void)testOAuthLogin_TokenClaims_FailsWithError {
+  GIDTokenClaim *authTimeClaim = [GIDTokenClaim authTimeClaim];
+  GIDTokenClaim *essentialAuthTimeClaim = [GIDTokenClaim essentialAuthTimeClaim];
+  NSSet *conflictingClaims = [NSSet setWithObjects:authTimeClaim, essentialAuthTimeClaim, nil];
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+                      keychainError:NO
+                   tokenClaimsError:YES
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO
+                useAdditionalScopes:NO
+                   additionalScopes:nil
+                        manualNonce:nil
+                        tokenClaims:conflictingClaims];
+
+  // Wait for the completion handler to be called
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  XCTAssertNotNil(_authError, @"An error object should have been returned.");
+  XCTAssertEqual(_authError.code, kGIDSignInErrorCodeAmbiguousClaims,
+                 @"The error code should be for ambiguous claims.");
+  XCTAssertEqualObjects(_authError.domain, kGIDSignInErrorDomain,
+                        @"The error domain should be the GIDSignIn error domain.");
+  XCTAssertEqualObjects(_authError.localizedDescription, kGIDTokenClaimErrorDescription,
+                        @"The error description should clearly explain the ambiguity.");
 }
 
 - (void)testSignOut {
@@ -1339,7 +1466,7 @@ static NSString *const kNewScope = @"newScope";
   NSError *handledError = [NSError errorWithDomain:kGIDSignInErrorDomain
                                               code:kGIDSignInErrorCodeEMM
                                           userInfo:emmError.userInfo];
-  
+
   completion(handledError);
 
   [self waitForExpectationsWithTimeout:1 handler:nil];
@@ -1424,12 +1551,14 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:tokenError
             emmPasscodeInfoRequired:emmPasscodeInfoRequired
                       keychainError:keychainError
+                   tokenClaimsError:NO
                      restoredSignIn:restoredSignIn
                      oldAccessToken:oldAccessToken
                         modalCancel:modalCancel
                 useAdditionalScopes:NO
                    additionalScopes:nil
-                        manualNonce:nil];
+                        manualNonce:nil
+                        tokenClaims:nil];
 }
 
 // The authorization flow with parameters to control which branches to take.
@@ -1438,12 +1567,14 @@ static NSString *const kNewScope = @"newScope";
                          tokenError:(NSError *)tokenError
             emmPasscodeInfoRequired:(BOOL)emmPasscodeInfoRequired
                       keychainError:(BOOL)keychainError
+                   tokenClaimsError:(BOOL)tokenClaimsError
                      restoredSignIn:(BOOL)restoredSignIn
                      oldAccessToken:(BOOL)oldAccessToken
                         modalCancel:(BOOL)modalCancel
                 useAdditionalScopes:(BOOL)useAdditionalScopes
-                   additionalScopes:(NSArray *)additionalScopes 
-                        manualNonce:(NSString *)nonce {
+                   additionalScopes:(NSArray *)additionalScopes
+                        manualNonce:(NSString *)nonce
+                        tokenClaims:(NSSet *)tokenClaims {
   if (restoredSignIn) {
     // clearAndAuthenticateWithOptions
     [[[_authorization expect] andReturn:_authState] authState];
@@ -1458,12 +1589,20 @@ static NSString *const kNewScope = @"newScope";
                                                                nonce:nonce
                                                          errorString:authError];
 
+  NSString *idToken = tokenClaims ? [OIDTokenResponse fatIDTokenWithAuthTime] : [OIDTokenResponse fatIDToken];
   OIDTokenResponse *tokenResponse =
-      [OIDTokenResponse testInstanceWithIDToken:[OIDTokenResponse fatIDToken]
+      [OIDTokenResponse testInstanceWithIDToken:idToken
                                     accessToken:restoredSignIn ? kAccessToken : nil
                                       expiresIn:oldAccessToken ? @(300) : nil
                                    refreshToken:kRefreshToken
                                    tokenRequest:nil];
+
+  if (tokenClaims) {
+    // Creating this stub to use `currentUser.idToken`.
+    id mockIDToken = OCMClassMock([GIDToken class]);
+    OCMStub([mockIDToken tokenString]).andReturn(tokenResponse.idToken);
+    OCMStub([_user idToken]).andReturn(mockIDToken);
+  }
 
   OIDTokenRequest *tokenRequest = [[OIDTokenRequest alloc]
       initWithConfiguration:authResponse.request.configuration
@@ -1533,8 +1672,15 @@ static NSString *const kNewScope = @"newScope";
                                        hint:_hint
                            additionalScopes:nil
                                       nonce:nonce
+                                tokenClaims:tokenClaims
                                  completion:completion];
       }
+    }
+
+    // When token claims are invalid, sign-in fails skipping the entire authorization flow.
+    // Thus, no need to verify `_authorization` or `_authState` as they won't be generated.
+    if (tokenClaimsError) {
+      return;
     }
 
     [_authorization verify];
@@ -1631,7 +1777,7 @@ static NSString *const kNewScope = @"newScope";
                                                     profileData:SAVE_TO_ARG_BLOCK(profileData)];
     }
   }
-  
+
   // CompletionCallback - mock server auth code parsing
   if (!keychainError) {
     [[[_authState expect] andReturn:tokenResponse] lastTokenResponse];
@@ -1653,9 +1799,9 @@ static NSString *const kNewScope = @"newScope";
     return;
   }
   [self waitForExpectationsWithTimeout:1 handler:nil];
-  
+
   [_authState verify];
-  
+
   XCTAssertTrue(_keychainSaved, @"should save to keychain");
   if (addScopesFlow) {
     XCTAssertNotNil(updatedTokenResponse);
@@ -1692,7 +1838,7 @@ static NSString *const kNewScope = @"newScope";
   [self waitForExpectationsWithTimeout:1 handler:nil];
   XCTAssertFalse(_keychainRemoved, @"should not remove keychain");
   XCTAssertFalse(_keychainSaved, @"should not save to keychain again");
-  
+
   if (restoredSignIn) {
     // Ignore the return value
     OCMVerify((void)[_keychainStore retrieveAuthSessionWithError:OCMArg.anyObjectRef]);

--- a/GoogleSignIn/Tests/Unit/GIDTokenClaimTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDTokenClaimTest.m
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#import <XCTest/XCTest.h>
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDTokenClaim.h"
+
+@interface GIDTokenClaimTest : XCTestCase
+@end
+
+@implementation GIDTokenClaimTest
+
+- (void)testAuthTimeClaim_PropertiesAreCorrect {
+  GIDTokenClaim *claim = [GIDTokenClaim authTimeClaim];
+  XCTAssertEqualObjects(claim.name, kAuthTimeClaimName);
+  XCTAssertFalse(claim.isEssential);
+}
+
+- (void)testEssentialAuthTimeClaim_PropertiesAreCorrect {
+  GIDTokenClaim *claim = [GIDTokenClaim essentialAuthTimeClaim];
+  XCTAssertEqualObjects(claim.name, kAuthTimeClaimName);
+  XCTAssertTrue(claim.isEssential);
+}
+
+- (void)testEquality_WithEqualClaims {
+  GIDTokenClaim *claim1 = [GIDTokenClaim authTimeClaim];
+  GIDTokenClaim *claim2 = [GIDTokenClaim authTimeClaim];
+  XCTAssertEqualObjects(claim1, claim2);
+  XCTAssertEqual(claim1.hash, claim2.hash);
+}
+
+- (void)testEquality_WithUnequalClaims {
+  GIDTokenClaim *claim1 = [GIDTokenClaim authTimeClaim];
+  GIDTokenClaim *claim2 = [GIDTokenClaim essentialAuthTimeClaim];
+  XCTAssertNotEqualObjects(claim1, claim2);
+}
+
+@end

--- a/GoogleSignIn/Tests/Unit/GIDTokenClaimsInternalOptionsTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDTokenClaimsInternalOptionsTest.m
@@ -1,0 +1,113 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "GoogleSignIn/Sources/GIDJSONSerializer/Fake/GIDFakeJSONSerializerImpl.h"
+#import "GoogleSignIn/Sources/GIDJSONSerializer/Implementation/GIDJSONSerializerImpl.h"
+#import "GoogleSignIn/Sources/GIDTokenClaimsInternalOptions.h"
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h"
+#import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDTokenClaim.h"
+
+static NSString *const kEssentialAuthTimeExpectedJSON = @"{\"id_token\":{\"auth_time\":{\"essential\":true}}}";
+static NSString *const kNonEssentialAuthTimeExpectedJSON = @"{\"id_token\":{\"auth_time\":{\"essential\":false}}}";
+
+@interface GIDTokenClaimsInternalOptionsTest : XCTestCase
+
+@property(nonatomic) GIDFakeJSONSerializerImpl *jsonSerializerFake;
+@property(nonatomic) GIDTokenClaimsInternalOptions *tokenClaimsInternalOptions;
+
+@end
+
+@implementation GIDTokenClaimsInternalOptionsTest
+
+- (void)setUp {
+  [super setUp];
+  _jsonSerializerFake = [[GIDFakeJSONSerializerImpl alloc] init];
+  _tokenClaimsInternalOptions = [[GIDTokenClaimsInternalOptions alloc] initWithJSONSerializer:_jsonSerializerFake];
+}
+
+- (void)tearDown {
+  _jsonSerializerFake = nil;
+  _tokenClaimsInternalOptions = nil;
+  [super tearDown];
+}
+
+#pragma mark - Input Validation Tests
+
+- (void)testValidatedJSONStringForClaims_WithNilInput_ShouldReturnNil {
+  XCTAssertNil([_tokenClaimsInternalOptions validatedJSONStringForClaims:nil error:nil]);
+}
+
+- (void)testValidatedJSONStringForClaims_WithEmptyInput_ShouldReturnNil {
+  XCTAssertNil([_tokenClaimsInternalOptions validatedJSONStringForClaims:[NSSet set] error:nil]);
+}
+
+#pragma mark - Correct Formatting Tests
+
+- (void)testValidatedJSONStringForClaims_WithNonEssentialClaim_IsCorrectlyFormatted {
+  NSSet *claims = [NSSet setWithObject:[GIDTokenClaim authTimeClaim]];
+  NSError *error;
+  NSString *result = [_tokenClaimsInternalOptions validatedJSONStringForClaims:claims error:&error];
+
+  XCTAssertNil(error);
+  XCTAssertEqualObjects(result, kNonEssentialAuthTimeExpectedJSON);
+}
+
+- (void)testValidatedJSONStringForClaims_WithEssentialClaim_IsCorrectlyFormatted {
+  NSSet *claims = [NSSet setWithObject:[GIDTokenClaim essentialAuthTimeClaim]];
+  NSError *error;
+  NSString *result = [_tokenClaimsInternalOptions validatedJSONStringForClaims:claims error:&error];
+
+  XCTAssertNil(error);
+  XCTAssertEqualObjects(result, kEssentialAuthTimeExpectedJSON);
+}
+
+#pragma mark - Client Error Handling Tests
+
+- (void)testValidatedJSONStringForClaims_WithConflictingClaims_ReturnsNilAndPopulatesError {
+  NSSet *claims = [NSSet setWithObjects:[GIDTokenClaim authTimeClaim],
+                                        [GIDTokenClaim essentialAuthTimeClaim],
+                                        nil];
+  NSError *error;
+  NSString *result = [_tokenClaimsInternalOptions validatedJSONStringForClaims:claims error:&error];
+
+  XCTAssertNil(result, @"Method should return nil for conflicting claims.");
+  XCTAssertNotNil(error, @"An error object should be populated.");
+  XCTAssertEqualObjects(error.domain, kGIDSignInErrorDomain, @"Error domain should be correct.");
+  XCTAssertEqual(error.code, kGIDSignInErrorCodeAmbiguousClaims,
+                 @"Error code should be for ambiguous claims.");
+}
+
+- (void)testValidatedJSONStringForClaims_WhenSerializationFails_ReturnsNilAndError {
+  NSSet *claims = [NSSet setWithObject:[GIDTokenClaim authTimeClaim]];
+  NSError *expectedJSONError = [NSError errorWithDomain:kGIDSignInErrorDomain
+                                                   code:kGIDSignInErrorCodeJSONSerializationFailure
+                                               userInfo:@{
+                                                 NSLocalizedDescriptionKey: kGIDJSONSerializationErrorDescription,
+                                               }];
+  _jsonSerializerFake.serializationError = expectedJSONError;
+  NSError *actualError;
+  NSString *result = [_tokenClaimsInternalOptions validatedJSONStringForClaims:claims
+                                                                         error:&actualError];
+
+  XCTAssertNil(result, @"The result should be nil when JSON serialization fails.");
+  XCTAssertEqualObjects(
+      actualError,
+      expectedJSONError,
+      @"The error from serialization should be passed back to the caller."
+  );
+}
+
+@end

--- a/GoogleSignIn/Tests/Unit/OIDAuthorizationRequest+Testing.h
+++ b/GoogleSignIn/Tests/Unit/OIDAuthorizationRequest+Testing.h
@@ -29,6 +29,6 @@ extern NSString * _Nonnull const OIDAuthorizationRequestTestingCodeVerifier;
 
 + (instancetype _Nonnull)testInstance;
 
-+ (instancetype _Nonnull)testInstanceWithNonce:(nullable NSString *)nonce;
-
++ (instancetype _Nonnull)testInstanceWithNonce:(nullable NSString *)nonce
+                          additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
 @end

--- a/GoogleSignIn/Tests/Unit/OIDAuthorizationRequest+Testing.m
+++ b/GoogleSignIn/Tests/Unit/OIDAuthorizationRequest+Testing.m
@@ -32,10 +32,12 @@ NSString *const OIDAuthorizationRequestTestingCodeVerifier = @"codeVerifier";
 @implementation OIDAuthorizationRequest (Testing)
 
 + (instancetype)testInstance {
-  return [self testInstanceWithNonce:nil];
+  return [self testInstanceWithNonce:nil additionalParameters:nil];
 }
 
-+ (instancetype)testInstanceWithNonce:(nullable NSString *)nonce {
++ (instancetype)testInstanceWithNonce:(nullable NSString *)nonce
+                 additionalParameters:
+                     (nullable NSDictionary<NSString *, NSString *> *)additionalParameters {
   return [[OIDAuthorizationRequest alloc]
       initWithConfiguration:[OIDServiceConfiguration testInstance]
                    clientId:OIDAuthorizationRequestTestingClientID
@@ -44,7 +46,7 @@ NSString *const OIDAuthorizationRequestTestingCodeVerifier = @"codeVerifier";
                 redirectURL:[NSURL URLWithString:@"http://test.com"]
                responseType:OIDResponseTypeCode
                       nonce:nonce
-       additionalParameters:nil];
+       additionalParameters:additionalParameters];
 }
 
 @end

--- a/GoogleSignIn/Tests/Unit/OIDAuthorizationResponse+Testing.m
+++ b/GoogleSignIn/Tests/Unit/OIDAuthorizationResponse+Testing.m
@@ -46,7 +46,10 @@
       [parameters addEntriesFromDictionary:additionalParameters];
     }
   }
-  return [[OIDAuthorizationResponse alloc] initWithRequest:[OIDAuthorizationRequest testInstanceWithNonce:nonce]
+  OIDAuthorizationRequest *request =
+      [OIDAuthorizationRequest testInstanceWithNonce:nonce
+                                additionalParameters:additionalParameters];
+  return [[OIDAuthorizationResponse alloc] initWithRequest:request
                                                 parameters:parameters];
 }
 

--- a/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h
+++ b/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h
@@ -33,6 +33,7 @@ extern NSString *const kUserID;
 extern NSString *const kHostedDomain;
 extern NSString *const kIssuer;
 extern NSString *const kAudience;
+extern NSString *const kAuthTime;
 extern NSTimeInterval const kIDTokenExpires;
 extern NSTimeInterval const kIssuedAt;
 
@@ -59,9 +60,18 @@ extern NSString * const kFatPictureURL;
                            refreshToken:(NSString *)refreshToken
                            tokenRequest:(OIDTokenRequest *)tokenRequest;
 
++ (instancetype)testInstanceWithIDToken:(NSString *)idToken
+                            accessToken:(NSString *)accessToken
+                              expiresIn:(NSNumber *)expiresIn
+                           refreshToken:(NSString *)refreshToken
+                               authTime:(NSString *)authTime
+                           tokenRequest:(OIDTokenRequest *)tokenRequest;
+
 + (NSString *)idToken;
 
 + (NSString *)fatIDToken;
+
++ (NSString *)fatIDTokenWithAuthTime;
 
 /**
  * @sub The subject of the ID token.
@@ -70,5 +80,7 @@ extern NSString * const kFatPictureURL;
 + (NSString *)idTokenWithSub:(NSString *)sub exp:(NSNumber *)exp;
 
 + (NSString *)idTokenWithSub:(NSString *)sub exp:(NSNumber *)exp fat:(BOOL)fat;
+
++ (NSString *)idTokenWithSub:(NSString *)sub exp:(NSNumber *)exp fat:(BOOL)fat authTime:(NSString *)authTime;
 
 @end

--- a/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.m
+++ b/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.m
@@ -38,6 +38,7 @@ NSString *const kUserID = @"12345679";
 NSString *const kHostedDomain = @"fakehosteddomain.com";
 NSString *const kIssuer = @"https://test.com";
 NSString *const kAudience = @"audience";
+NSString *const kAuthTime = @"1757753868";
 NSTimeInterval const kIDTokenExpires = 1000;
 NSTimeInterval const kIssuedAt = 0;
 
@@ -70,6 +71,21 @@ NSString * const kFatPictureURL = @"fake_user_picture_url";
                               expiresIn:(NSNumber *)expiresIn
                            refreshToken:(NSString *)refreshToken
                            tokenRequest:(OIDTokenRequest *)tokenRequest {
+  return [OIDTokenResponse testInstanceWithIDToken:idToken
+                                       accessToken:accessToken
+                                         expiresIn:expiresIn
+                                      refreshToken:refreshToken
+                                          authTime:nil
+                                      tokenRequest:tokenRequest];
+}
+
++ (instancetype)testInstanceWithIDToken:(NSString *)idToken
+                            accessToken:(NSString *)accessToken
+                              expiresIn:(NSNumber *)expiresIn
+                           refreshToken:(NSString *)refreshToken
+                               authTime:(NSString *)authTime
+                           tokenRequest:(OIDTokenRequest *)tokenRequest {
+
   NSMutableDictionary<NSString *, NSString *> *parameters = [[NSMutableDictionary alloc] initWithDictionary:@{
     @"access_token" : accessToken ?: kAccessToken,
     @"expires_in" : expiresIn ?: @(kAccessTokenExpiresIn),
@@ -93,11 +109,24 @@ NSString * const kFatPictureURL = @"fake_user_picture_url";
   return [self idTokenWithSub:kUserID exp:@(kIDTokenExpires) fat:YES];
 }
 
++ (NSString *)fatIDTokenWithAuthTime {
+  return [self idTokenWithSub:kUserID exp:@(kIDTokenExpires) fat:YES authTime:kAuthTime];
+}
+
 + (NSString *)idTokenWithSub:(NSString *)sub exp:(NSNumber *)exp {
   return [self idTokenWithSub:sub exp:exp fat:NO];
 }
 
-+ (NSString *)idTokenWithSub:(NSString *)sub exp:(NSNumber *)exp fat:(BOOL)fat {
++ (NSString *)idTokenWithSub:(NSString *)sub
+                         exp:(NSNumber *)exp
+                         fat:(BOOL)fat {
+  return [self idTokenWithSub:kUserID exp:exp fat:fat authTime:nil];
+}
+
++ (NSString *)idTokenWithSub:(NSString *)sub
+                         exp:(NSNumber *)exp
+                         fat:(BOOL)fat
+                    authTime:(NSString *)authTime{
   NSError *error;
   NSDictionary *headerContents = @{
     @"alg" : kAlg,
@@ -110,7 +139,7 @@ NSString * const kFatPictureURL = @"fake_user_picture_url";
   if (error || !headerJson) {
     return nil;
   }
-  NSMutableDictionary<NSString *, NSString *> *payloadContents =
+  NSMutableDictionary<NSString *, id> *payloadContents =
       [NSMutableDictionary dictionaryWithDictionary:@{
     @"sub" : sub,
     @"hd"  : kHostedDomain,
@@ -125,6 +154,11 @@ NSString * const kFatPictureURL = @"fake_user_picture_url";
       kFatGivenNameKey : kFatGivenName,
       kFatFamilyNameKey : kFatFamilyName,
       kFatPictureURLKey : kFatPictureURL,
+    }];
+  }
+  if (authTime) {
+    [payloadContents addEntriesFromDictionary:@{
+          @"auth_time": kAuthTime,
     }];
   }
   NSData *payloadJson = [NSJSONSerialization dataWithJSONObject:payloadContents

--- a/Samples/Swift/DaysUntilBirthday/Shared/Services/GoogleSignInAuthenticator.swift
+++ b/Samples/Swift/DaysUntilBirthday/Shared/Services/GoogleSignInAuthenticator.swift
@@ -20,6 +20,7 @@ import GoogleSignIn
 /// An observable class for authenticating via Google.
 final class GoogleSignInAuthenticator: ObservableObject {
   private var authViewModel: AuthenticationViewModel
+  private var tokenClaims: Set<GIDTokenClaim> = Set([GIDTokenClaim.authTime()])
 
   /// Creates an instance of this authenticator.
   /// - parameter authViewModel: The view model this authenticator will set logged in status on.
@@ -41,7 +42,8 @@ final class GoogleSignInAuthenticator: ObservableObject {
       withPresenting: rootViewController,
       hint: nil,
       additionalScopes: nil,
-      nonce: manualNonce
+      nonce: manualNonce,
+      tokenClaims: tokenClaims
     ) { signInResult, error in
       guard let signInResult = signInResult else {
         print("Error! \(String(describing: error))")
@@ -66,7 +68,10 @@ final class GoogleSignInAuthenticator: ObservableObject {
       return
     }
 
-    GIDSignIn.sharedInstance.signIn(withPresenting: presentingWindow) { signInResult, error in
+    GIDSignIn.sharedInstance.signIn(
+      withPresenting: presentingWindow,
+      tokenClaims: tokenClaims
+    ) { signInResult, error in
       guard let signInResult = signInResult else {
         print("Error! \(String(describing: error))")
         return

--- a/Samples/Swift/DaysUntilBirthday/iOS/UserProfileView.swift
+++ b/Samples/Swift/DaysUntilBirthday/iOS/UserProfileView.swift
@@ -35,6 +35,9 @@ struct UserProfileView: View {
               Text(userProfile.name)
                 .font(.headline)
               Text(userProfile.email)
+              if let authTimeString = authViewModel.formattedAuthTimeString {
+                Text("Last sign-in date: \(authTimeString)")
+              }
             }
           }
           NavigationLink(NSLocalizedString("View Days Until Birthday", comment: "View birthday days"),

--- a/Samples/Swift/DaysUntilBirthday/macOS/UserProfileView.swift
+++ b/Samples/Swift/DaysUntilBirthday/macOS/UserProfileView.swift
@@ -19,6 +19,9 @@ struct UserProfileView: View {
               Text(userProfile.name)
                 .font(.headline)
               Text(userProfile.email)
+              if let authTimeString = authViewModel.formattedAuthTimeString {
+                Text("Last sign-in date: \(authTimeString)")
+              }
             }
           }
           Button(NSLocalizedString("Sign Out", comment: "Sign out button"), action: signOut)


### PR DESCRIPTION
This PR addresses a runtime crash that occurs when the dictionary returned by `additionalTokenRefreshParametersForAuthSession:` contains non-string values, leading to a type mismatch in GTMAppAuth.

This fix is implemented in `GIDEMMSupport` by iterating through the additionalParameters dictionary and converts values to strings with the following logic :- 
1. `NSString` values: Preserves them as-is.
2. `NSNumber` values: Converts booleans to their string representation ("true" or "false") and all other numbers to their standard string value.
3. `NSArray` and `NSDictionary` values: Serializes them into a single, compact JSON string.

This ensures that the dictionary returned to GTMAppAuth is always of the correct type.