### PR TITLE
Add unit tests for AMR claim

### DIFF
--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -922,7 +922,7 @@ static NSString *const kMultipleClaimsJsonString =
                         kAuthTime,
                         @"The 'auth_time' claim should be present and correct.");
   XCTAssertEqualObjects(receivedClaims[@"amr"],
-                        [OIDTokenResponse testAMRValues],
+                        [OIDTokenResponse stubbedAMRValues],
                         @"The 'amr' claim should be present and correct.");
 }
 

--- a/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h
+++ b/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.h
@@ -66,7 +66,7 @@ extern NSString * const kFatPictureURL;
 
 + (NSString *)fatIDTokenWithClaims;
 
-+ (NSArray<NSString *> *)testAMRValues;
++ (NSArray<NSString *> *)stubbedAMRValues;
 
 /**
  * @sub The subject of the ID token.

--- a/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.m
+++ b/GoogleSignIn/Tests/Unit/OIDTokenResponse+Testing.m
@@ -98,7 +98,7 @@ NSString * const kFatPictureURL = @"fake_user_picture_url";
   return [self idTokenWithSub:kUserID exp:@(kIDTokenExpires) fat:YES claims:YES];
 }
 
-+ (NSArray<NSString *> *)testAMRValues {
++ (NSArray<NSString *> *)stubbedAMRValues {
   return @[ @"pwd", @"mfa", @"otp" ];
 }
 
@@ -148,7 +148,7 @@ NSString * const kFatPictureURL = @"fake_user_picture_url";
   if (claims) {
     [payloadContents addEntriesFromDictionary:@{
           @"auth_time": kAuthTime,
-          @"amr": [OIDTokenResponse testAMRValues],
+          @"amr": [OIDTokenResponse stubbedAMRValues],
     }];
   }
   NSData *payloadJson = [NSJSONSerialization dataWithJSONObject:payloadContents


### PR DESCRIPTION
This PR adds unit tests for the `AMR` claim within `GIDSignInTest`.

It also includes a refactor of existing tests to improve maintainability and scalability:
- Updates existing tests in `GIDSignInTest` and `OIDTokenResponse + Testing` for a cleaner codebase.
- Removes `testInstanceWithIDToken...authTime:(NSString *)authTime...` as no intended usage was found.
- Updates `fatIDTokenWithAuthTime` to `fatIDTokenWithClaims` to better reflect its behavior.
- Renames existing tests and parameters (e.g., `authTime` to `claims`) to allow tests to be more easily extended in the future.