### PR TITLE
Move GIDSignInButton import outside of conditional

### DIFF
--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GoogleSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GoogleSignIn.h
@@ -25,6 +25,4 @@
 #import "GIDToken.h"
 #import "GIDSignInResult.h"
 #import "GIDClaim.h"
-#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 #import "GIDSignInButton.h"
-#endif


### PR DESCRIPTION
GIDSignInButton already gates internally for the proper OS, and gating in the umbrella header is causing build warnings in Xcode

Supersedes #342