### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@3e15ea8318eee9b333819ec77a36aca8d39df13e # tag=v1.1.1
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `ossf/scorecard-action` | [`3e15ea8`](https://github.com/ossf/scorecard-action/commit/3e15ea8318eee9b333819ec77a36aca8d39df13e) | [`4eaacf0`](https://github.com/ossf/scorecard-action/commit/4eaacf0543bb3f2c246792bd56e8cdeffafb205a) | [Release](https://github.com/ossf/scorecard-action/releases/tag/v2.4.3) | scorecards.yml |

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
