### PR TITLE
fix: include all public headers unconditionally in umbrella header

### DIFF
--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GoogleSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GoogleSignIn.h
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#import <TargetConditionals.h>
-
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import "GIDAppCheckError.h"
-#endif
 #import "GIDConfiguration.h"
 #import "GIDGoogleUser.h"
 #import "GIDProfileData.h"


### PR DESCRIPTION
## Problem

`GIDAppCheckError.h` and `GIDSignInButton.h` are conditionally imported in the umbrella header (`GoogleSignIn.h`) using `#if TARGET_OS_IOS` guards, but the module map declares them unconditionally. This produces warnings during Xcode's precompiled module generation:

```
warning: umbrella header for module 'GoogleSignIn' does not include header 'GIDAppCheckError.h'
warning: umbrella header for module 'GoogleSignIn' does not include header 'GIDSignInButton.h'
```

This affects every project that uses GoogleSignIn via SPM on macOS.

## Fix

Remove the `#if TARGET_OS` guard around the imports in `GoogleSignIn.h`. Both headers already have their own internal platform guards:

- `GIDAppCheckError.h`: `#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST`
- `GIDSignInButton.h`: `#if TARGET_OS_IOS || TARGET_OS_MACCATALYST`

So importing them unconditionally in the umbrella header is safe — they compile to empty on unsupported platforms.

## Testing

- Built macOS and iOS targets with this change — zero umbrella header warnings
- No functional changes — the headers' internal guards still control compilation