### PR TITLE
Update AppAuth dependency minimum to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Update the AppAuth-iOS dependency to version 2.1.0 ([#954](https://github.com/openid/AppAuth-iOS/pull/954), [#955](https://github.com/openid/AppAuth-iOS/pull/955))
+
 # 9.1.0
 - Allow requesting `claims` (currently, only `auth_time`) via [Sign-in methods](https://github.com/google/GoogleSignIn-iOS/blob/gandhiakshat/update-changelog-for-9.1.0-release/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h#L240) ([#550](https://github.com/google/GoogleSignIn-iOS/pull/550), [#552](https://github.com/google/GoogleSignIn-iOS/pull/552), [#553](https://github.com/google/GoogleSignIn-iOS/pull/553), [#569](https://github.com/google/GoogleSignIn-iOS/pull/569))
 - Update `addScopes:` methods in `GIDSignIn` to include previously requested `claims` ([#557](https://github.com/google/GoogleSignIn-iOS/pull/557))

--- a/GoogleSignIn.podspec
+++ b/GoogleSignIn.podspec
@@ -34,7 +34,7 @@ The Google Sign-In SDK allows users to sign in with their Google account from th
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
   s.dependency 'AppCheckCore', '~> 11.0'
-  s.dependency 'AppAuth', '~> 2.0'
+  s.dependency 'AppAuth', '~> 2.1'
   s.dependency 'GTMAppAuth', '~> 5.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 3.3'
   s.resource_bundle = {

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -201,7 +201,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 - (BOOL)handleURL:(NSURL *)url {
   // Check if the callback path matches the expected one for a URL from Safari/Chrome/SafariVC.
   if ([url.path isEqual:kBrowserCallbackPath]) {
-    if ([_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:url]) {
+    if ([_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:url error:nil]) {
       _currentAuthorizationFlow = nil;
       return YES;
     }

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/openid/AppAuth-iOS.git",
-      from: "2.0.0"),
+      from: "2.1.0"),
     .package(
       url: "https://github.com/google/app-check.git",
       from: "11.0.0"),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -44,7 +44,7 @@ let package = Package(
     .package(
       name: "AppAuth",
       url: "https://github.com/openid/AppAuth-iOS.git",
-      from: "2.0.0"),
+      from: "2.1.0"),
     .package(
       name: "AppCheck",
       url: "https://github.com/google/app-check.git",

--- a/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayForPod.xcodeproj/project.pbxproj
+++ b/Samples/Swift/DaysUntilBirthday/DaysUntilBirthdayForPod.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		736F49BC270E102C00580053 /* BirthdayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736F49BB270E102C00580053 /* BirthdayViewModel.swift */; };
 		739FCC46270E467600C92042 /* BirthdayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739FCC45270E467600C92042 /* BirthdayView.swift */; };
 		739FCC48270E659A00C92042 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739FCC47270E659A00C92042 /* Birthday.swift */; };
+		F8CE6602270E659A00C92042 /* Claim.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CE6601270E659A00C92042 /* Claim.swift */; };
 		73DB41892805FBA90028B8D3 /* DaysUntilBirthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7345AD022703D9470020AFB1 /* DaysUntilBirthday.swift */; };
 		73DB418A2805FBC00028B8D3 /* GoogleSignInAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7345AD172703D9C30020AFB1 /* GoogleSignInAuthenticator.swift */; };
 		73DB418B2805FBC40028B8D3 /* BirthdayLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736F49B9270E05E200580053 /* BirthdayLoader.swift */; };
@@ -34,6 +35,7 @@
 		73DB41922805FC010028B8D3 /* UserProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7345AD142703D9C30020AFB1 /* UserProfileImageView.swift */; };
 		73DB41932805FC3B0028B8D3 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7173A527F5110F00910319 /* UserProfileView.swift */; };
 		73DB41952805FC5F0028B8D3 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739FCC47270E659A00C92042 /* Birthday.swift */; };
+		F8CE66032805FC5F0028B8D3 /* Claim.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CE6601270E659A00C92042 /* Claim.swift */; };
 		73DB419628060A9A0028B8D3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7345AD062703D9480020AFB1 /* Assets.xcassets */; };
 		C1B5D38D282AFE870068D12B /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = C1B5D38C282AFE870068D12B /* README.md */; };
 		EEEEE201864437604E97D3B4 /* Pods_DaysUntilBirthdayForPod__iOS_.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F329EC9CE4A0A4AF2280834F /* Pods_DaysUntilBirthdayForPod__iOS_.framework */; };
@@ -61,6 +63,7 @@
 		736F49BB270E102C00580053 /* BirthdayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthdayViewModel.swift; sourceTree = "<group>"; };
 		739FCC45270E467600C92042 /* BirthdayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthdayView.swift; sourceTree = "<group>"; };
 		739FCC47270E659A00C92042 /* Birthday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Birthday.swift; sourceTree = "<group>"; };
+		F8CE6601270E659A00C92042 /* Claim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Claim.swift; sourceTree = "<group>"; };
 		7542DB53C46DFA9B71387188 /* Pods-DaysUntilBirthdayForPod (iOS).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DaysUntilBirthdayForPod (iOS).release.xcconfig"; path = "Target Support Files/Pods-DaysUntilBirthdayForPod (iOS)/Pods-DaysUntilBirthdayForPod (iOS).release.xcconfig"; sourceTree = "<group>"; };
 		926A15D393D684C68E09FB0F /* Pods_DaysUntilBirthdayForPod__macOS_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DaysUntilBirthdayForPod__macOS_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7CC09BA1B68EB1881A08E87 /* Pods-DaysUntilBirthdayForPod(macOS).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DaysUntilBirthdayForPod(macOS).debug.xcconfig"; path = "Target Support Files/Pods-DaysUntilBirthdayForPod(macOS)/Pods-DaysUntilBirthdayForPod(macOS).debug.xcconfig"; sourceTree = "<group>"; };
@@ -205,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				739FCC47270E659A00C92042 /* Birthday.swift */,
+				F8CE6601270E659A00C92042 /* Claim.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -413,6 +417,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				739FCC48270E659A00C92042 /* Birthday.swift in Sources */,
+				F8CE6602270E659A00C92042 /* Claim.swift in Sources */,
 				739FCC46270E467600C92042 /* BirthdayView.swift in Sources */,
 				7345AD1B2703D9C30020AFB1 /* SignInView.swift in Sources */,
 				7345AD212703D9C30020AFB1 /* GoogleSignInAuthenticator.swift in Sources */,
@@ -438,6 +443,7 @@
 				73DB418C2805FBC80028B8D3 /* UserProfileImageLoader.swift in Sources */,
 				73DB418E2805FBD40028B8D3 /* BirthdayViewModel.swift in Sources */,
 				73DB41952805FC5F0028B8D3 /* Birthday.swift in Sources */,
+				F8CE66032805FC5F0028B8D3 /* Claim.swift in Sources */,
 				73DB418A2805FBC00028B8D3 /* GoogleSignInAuthenticator.swift in Sources */,
 				73DB41932805FC3B0028B8D3 /* UserProfileView.swift in Sources */,
 				73DB41892805FBA90028B8D3 /* DaysUntilBirthday.swift in Sources */,


### PR DESCRIPTION
Raises the AppAuth-iOS dependency minimum to 2.1.0 ([release notes](https://github.com/openid/AppAuth-iOS/releases/tag/2.1.0)) ahead of the GoogleSignIn-iOS 9.2.0 release, and adopts the new AppAuth API:

- `GoogleSignIn.podspec`: `AppAuth` `~> 2.0` → `~> 2.1`
- `Package.swift` / `Package@swift-5.5.swift`: AppAuth-iOS `from: "2.0.0"` → `from: "2.1.0"`
- `CHANGELOG.md`: entry under Unreleased
- `GIDSignIn.m`: adopt `resumeExternalUserAgentFlowWithURL:error:` (passing a nil error outparam, behaviorally identical to the now-deprecated `resumeExternalUserAgentFlowWithURL:`). Required alongside the bump: AppAuth 2.1.0 deprecates the old selector, and the resulting warning fails `pod lib lint`. Since 2.1.0 is live on the CocoaPods trunk, `main`'s `~> 2.0` already resolves to it — this failure will exist on all PRs until this change lands. Notably, the old method was swapped to call the new one, so this change is net-neutral on risk.
- `Samples/Swift/DaysUntilBirthday`: add `Claim.swift` to the DaysUntilBirthdayForPod project so the sample builds with CocoaPods (folded in from #604, which is closed as superseded).

AppAuth 2.1.0 brings the in-app browser fallback removal (openid/AppAuth-iOS#954) and `resumeExternalUserAgentFlowWithURL:error:` (openid/AppAuth-iOS#955). SPM dependency resolution verified locally (AppAuth resolves at 2.1.0).

Note for reviewers: `swift-button-functional-test` is a pre-existing flake (same failures on `main` pushes from March–April) and is unrelated to these changes.

SKIP_INTEGRATION_TESTS=YES
