### PR TITLE
Fix crash in `additionalTokenRefreshParameters` when `emmSupport` is `nil`

### DIFF
--- a/GoogleSignIn/Sources/GIDEMMSupport.h
+++ b/GoogleSignIn/Sources/GIDEMMSupport.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
     (NSDictionary *)parameters;
 
 /// Gets a new set of URL parameters that also contains EMM-related URL parameters if needed.
+///
+/// @note This function only returns parameter keys in the `NSDictionary` for string/number/bools.
 + (NSDictionary<NSString *,NSString *> *)parametersWithParameters:(NSDictionary *)parameters
                                                        emmSupport:(nullable NSString *)emmSupport
                                            isPasscodeInfoRequired:(BOOL)isPasscodeInfoRequired;

--- a/GoogleSignIn/Sources/GIDEMMSupport.m
+++ b/GoogleSignIn/Sources/GIDEMMSupport.m
@@ -95,7 +95,7 @@ typedef NS_ENUM(NSInteger, ErrorCode) {
                                                        emmSupport:(nullable NSString *)emmSupport
                                            isPasscodeInfoRequired:(BOOL)isPasscodeInfoRequired {
   if (!emmSupport) {
-    return parameters;
+    return [GIDEMMSupport dictionaryWithStringValuesFromDictionary:parameters];
   }
   NSMutableDictionary *allParameters = [(parameters ?: @{}) mutableCopy];
   allParameters[kEMMSupportParameterName] = emmSupport;

--- a/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
@@ -354,6 +354,36 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
                 @"The final value should be of a NSString type.");
 }
 
+- (void)testParametersWithParameters_withEMMSupportNil_isConvertedToString {
+  NSDictionary *inputParameters = @{ @"number_key": @12345 };
+
+  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:inputParameters
+                                                                     emmSupport:nil
+                                                         isPasscodeInfoRequired:NO];
+
+  XCTAssertEqualObjects(stringifiedParameters[@"number_key"], @"12345",
+                        @"The NSNumber should be converted to a string.");
+  XCTAssertTrue([stringifiedParameters[@"number_key"] isKindOfClass:[NSString class]],
+                @"The final value should be of a NSString type.");
+}
+
+- (void)testParametersWithParameters_withPasscodeInfoRequired_isConvertedToString {
+  NSDictionary *inputParameters = @{ @"number_key": @12345 };
+
+  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:inputParameters
+                                                                     emmSupport:@"1"
+                                                         isPasscodeInfoRequired:YES];
+
+  XCTAssertEqualObjects(stringifiedParameters[@"number_key"], @"12345",
+                        @"The NSNumber should be converted to a string.");
+  XCTAssertTrue([stringifiedParameters[@"number_key"] isKindOfClass:[NSString class]],
+                @"The final value should be of a NSString type.");
+  XCTAssertNotNil(stringifiedParameters[kEMMPasscodeInfoKey],
+                  @"The passcode info key should be present when requested.");
+  XCTAssertTrue([stringifiedParameters[kEMMPasscodeInfoKey] isKindOfClass:[NSString class]],
+                @"The passcode info value should be of a NSString type.");
+}
+
 # pragma mark - Helpers
 
 - (NSString *)systemVersion {

--- a/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
@@ -354,6 +354,23 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
                 @"The final value should be of a NSString type.");
 }
 
+- (void)testParametersWithParameters_withPasscodeInfoRequired_isConvertedToString {
+  NSDictionary *inputParameters = @{ @"number_key": @12345 };
+
+  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:inputParameters
+                                                                     emmSupport:@"1"
+                                                         isPasscodeInfoRequired:YES];
+
+  XCTAssertEqualObjects(stringifiedParameters[@"number_key"], @"12345",
+                        @"The NSNumber should be converted to a string.");
+  XCTAssertTrue([stringifiedParameters[@"number_key"] isKindOfClass:[NSString class]],
+                @"The final value should be of a NSString type.");
+  XCTAssertNotNil(stringifiedParameters[kEMMPasscodeInfoKey],
+                  @"The passcode info key should be present when requested.");
+  XCTAssertTrue([stringifiedParameters[kEMMPasscodeInfoKey] isKindOfClass:[NSString class]],
+                @"The passcode info value should be of a NSString type.");
+}
+
 - (void)testParametersWithParameters_withEMMSupportNil_isConvertedToString {
   NSDictionary *inputParameters = @{ @"number_key": @12345 };
 
@@ -376,23 +393,6 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
                         @"The EMM support parameter should append any valid NSString it receives.");
   XCTAssertTrue([stringifiedParameters[kEMMKey] isKindOfClass:[NSString class]],
                 @"The final value should be of a NSString type.");
-}
-
-- (void)testParametersWithParameters_withPasscodeInfoRequired_isConvertedToString {
-  NSDictionary *inputParameters = @{ @"number_key": @12345 };
-
-  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:inputParameters
-                                                                     emmSupport:@"1"
-                                                         isPasscodeInfoRequired:YES];
-
-  XCTAssertEqualObjects(stringifiedParameters[@"number_key"], @"12345",
-                        @"The NSNumber should be converted to a string.");
-  XCTAssertTrue([stringifiedParameters[@"number_key"] isKindOfClass:[NSString class]],
-                @"The final value should be of a NSString type.");
-  XCTAssertNotNil(stringifiedParameters[kEMMPasscodeInfoKey],
-                  @"The passcode info key should be present when requested.");
-  XCTAssertTrue([stringifiedParameters[kEMMPasscodeInfoKey] isKindOfClass:[NSString class]],
-                @"The passcode info value should be of a NSString type.");
 }
 
 # pragma mark - Helpers

--- a/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
@@ -354,6 +354,36 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
                 @"The final value should be of a NSString type.");
 }
 
+- (void)testParametersWithParameters_withEMMSupportNil_isConvertedToString {
+  NSDictionary *inputParameters = @{ @"number_key": @12345 };
+
+  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:inputParameters
+                                                                     emmSupport:nil
+                                                         isPasscodeInfoRequired:NO];
+
+  XCTAssertEqualObjects(stringifiedParameters[@"number_key"], @"12345",
+                        @"The NSNumber should be converted to a string.");
+  XCTAssertTrue([stringifiedParameters[@"number_key"] isKindOfClass:[NSString class]],
+                @"The final value should be of a NSString type.");
+}
+
+- (void)testParametersWithParameters_withArbitraryEMMSupport_isConvertedToString {
+  NSDictionary *inputParameters = @{ @"number_key": @12345 };
+
+  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:inputParameters
+                                                                     emmSupport:@"False"
+                                                         isPasscodeInfoRequired:NO];
+
+  XCTAssertEqualObjects(stringifiedParameters[@"number_key"], @"12345",
+                        @"The NSNumber should be converted to a string.");
+  XCTAssertTrue([stringifiedParameters[@"number_key"] isKindOfClass:[NSString class]],
+                @"The final value should be of a NSString type.");
+  XCTAssertEqualObjects(stringifiedParameters[kEMMKey], @"False",
+                        @"The EMM support parameter should append any valid NSString it receives.");
+  XCTAssertTrue([stringifiedParameters[kEMMKey] isKindOfClass:[NSString class]],
+                @"The final value should be of a NSString type.");
+}
+
 - (void)testParametersWithParameters_withPasscodeInfoRequired_isConvertedToString {
   NSDictionary *inputParameters = @{ @"number_key": @12345 };
 
@@ -369,30 +399,6 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
                   @"The passcode info key should be present when requested.");
   XCTAssertTrue([stringifiedParameters[kEMMPasscodeInfoKey] isKindOfClass:[NSString class]],
                 @"The passcode info value should be of a NSString type.");
-}
-
-- (void)testParametersWithParameters_withEMMSupportNil_isConvertedToString {
-  NSDictionary *inputParameters = @{ @"number_key": @12345 };
-
-  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:inputParameters
-                                                                     emmSupport:nil
-                                                         isPasscodeInfoRequired:NO];
-
-  XCTAssertEqualObjects(stringifiedParameters[@"number_key"], @"12345",
-                        @"The NSNumber should be converted to a string.");
-  XCTAssertTrue([stringifiedParameters[@"number_key"] isKindOfClass:[NSString class]],
-                @"The final value should be of a NSString type.");
-}
-
-- (void)testParametersWithParameters_withArbitraryEMMSupport_isAppended {
-  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:@{}
-                                                                     emmSupport:@"False"
-                                                         isPasscodeInfoRequired:NO];
-
-  XCTAssertEqualObjects(stringifiedParameters[kEMMKey], @"False",
-                        @"The EMM support parameter should append any valid NSString it receives.");
-  XCTAssertTrue([stringifiedParameters[kEMMKey] isKindOfClass:[NSString class]],
-                @"The final value should be of a NSString type.");
 }
 
 # pragma mark - Helpers

--- a/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDEMMSupportTest.m
@@ -367,6 +367,17 @@ static NSString *const kEMMPasscodeInfoKey = @"emm_passcode_info";
                 @"The final value should be of a NSString type.");
 }
 
+- (void)testParametersWithParameters_withArbitraryEMMSupport_isAppended {
+  NSDictionary *stringifiedParameters = [GIDEMMSupport parametersWithParameters:@{}
+                                                                     emmSupport:@"False"
+                                                         isPasscodeInfoRequired:NO];
+
+  XCTAssertEqualObjects(stringifiedParameters[kEMMKey], @"False",
+                        @"The EMM support parameter should append any valid NSString it receives.");
+  XCTAssertTrue([stringifiedParameters[kEMMKey] isKindOfClass:[NSString class]],
+                @"The final value should be of a NSString type.");
+}
+
 - (void)testParametersWithParameters_withPasscodeInfoRequired_isConvertedToString {
   NSDictionary *inputParameters = @{ @"number_key": @12345 };
 


### PR DESCRIPTION
Overview
This PR fixes an edge case missed by the previous fix for the Swift casting crash in `additionalTokenRefreshParameters` (#564).

The Problem
The previous fix correctly converted non-string values (like `NSNumber`) into their `NSString` representations to avoid a Swift type mismatch exception. However, it missed the scenario where `emmSupport` is `nil` or `NO`. In that case, `[GIDEMMSupport parametersWithParameters:emmSupport:isPasscodeInfoRequired:]` returned the original parameters dictionary early, bypassing the newly added string conversion helper.

The Fix
This change updates the early return block to apply `[GIDEMMSupport dictionaryWithStringValuesFromDictionary:parameters]`, ensuring that the dictionary is safely stringified regardless of the `emmSupport` configuration.