### PR TITLE
Add App Check support for macOS

### DIFF
--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.h
@@ -15,7 +15,7 @@
 #import <TargetConditionals.h>
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_OSX
 #import <AppCheckCore/GACAppCheckProvider.h>
 
 @class GACAppCheckToken;

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.m
@@ -14,7 +14,7 @@
 
 #import "GoogleSignIn/Sources/GIDAppCheck/Implementations/Fake/GIDAppCheckProviderFake.h"
 
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_OSX
 
 #import <AppCheckCore/GACAppCheckToken.h>
 

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h
@@ -16,7 +16,7 @@
 
 #import <TargetConditionals.h>
 
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_OSX
 
 #import <Foundation/Foundation.h>
 

--- a/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
+++ b/GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.m
@@ -16,7 +16,7 @@
 
 #import "GoogleSignIn/Sources/GIDAppCheck/Implementations/GIDAppCheck.h"
 
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_OSX
 
 #import <AppCheckCore/GACAppCheck.h>
 #import <AppCheckCore/GACAppCheckSettings.h>

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAppCheckError.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDAppCheckError.h
@@ -16,7 +16,7 @@
 
 #import <TargetConditionals.h>
 
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_OSX
 
 #import <Foundation/Foundation.h>
 

--- a/GoogleSignIn/Tests/Unit/GIDAppCheckTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDAppCheckTest.m
@@ -14,7 +14,7 @@
 
 #import <TargetConditionals.h>
 
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_OSX
 
 #import <XCTest/XCTest.h>
 #import <AppCheckCore/GACAppCheckToken.h>


### PR DESCRIPTION
Why
Add macOS support to the Firebase App Check integration so GoogleSignIn can compile and run App Check code paths on macOS builds. This enables safer usage of App Check where platform support exists and provides consistent behavior across Apple platforms.

What changed
- Widen Objective-C preprocessor guards to include TARGET_OS_OSX so App Check implementation, fake provider, error definitions, and unit tests are available on macOS.
- Files updated: GIDAppCheck.h, GIDAppCheck.m, GIDAppCheckProviderFake.h, GIDAppCheckProviderFake.m, GIDAppCheckError.h, GIDAppCheckTest.m.

Approach
Used conservative conditional compilation to avoid changing behavior on iOS while enabling macOS compilation. No API surface or runtime behavior changes beyond making the App Check code available when building for macOS. Tests were adjusted to compile on macOS by exposing the test file under macOS builds.

Notes for reviewers
- This change only widens compilation availability; macOS runtime entitlements (App Attest availability, keychain access groups) may require additional platform-specific configuration in consumer apps. Documented limitations should be added if needed in follow-ups.

Fixes: #602