### PR TITLE
Consolidate SDK logging parameters to prep for new ones

### DIFF
--- a/GoogleSignIn/Sources/GIDGoogleUser.m
+++ b/GoogleSignIn/Sources/GIDGoogleUser.m
@@ -153,8 +153,7 @@ static NSTimeInterval const kMinimalTimeToExpire = 60.0;
   [additionalParameters addEntriesFromDictionary:
       self.authState.lastTokenResponse.request.additionalParameters];
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-  additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
-  additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
+  [additionalParameters addEntriesFromDictionary:[GIDSignInPreferences loggingParameters]];
 
   OIDTokenRequest *tokenRefreshRequest =
       [self.authState tokenRefreshRequestWithAdditionalParameters:additionalParameters];

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -579,9 +579,9 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   revokeURLString = [NSString stringWithFormat:@"%@&%@=%@&%@=%@",
                      revokeURLString,
                      kSDKVersionLoggingParameter,
-                     GIDVersion(),
+                     [GIDSignInPreferences sdkVersion],
                      kEnvironmentLoggingParameter,
-                     GIDEnvironment()];
+                     [GIDSignInPreferences environment]];
   NSURL *revokeURL = [NSURL URLWithString:revokeURLString];
   [self startFetchURL:revokeURL
               fromAuthState:authState
@@ -918,8 +918,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 #elif TARGET_OS_OSX || TARGET_OS_MACCATALYST
   [additionalParameters addEntriesFromDictionary:options.extraParams];
 #endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
-  additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
-  additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
+  [additionalParameters addEntriesFromDictionary:[GIDSignInPreferences loggingParameters]];
 
   return additionalParameters;
 }
@@ -1054,8 +1053,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                                    emmSupport:authFlow.emmSupport
                        isPasscodeInfoRequired:passcodeInfoRequired.length > 0]];
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-  additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
-  additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
+  [additionalParameters addEntriesFromDictionary:[GIDSignInPreferences loggingParameters]];
 
   OIDTokenRequest *tokenRequest;
   if (!authState.lastTokenResponse.accessToken &&

--- a/GoogleSignIn/Sources/GIDSignInPreferences.h
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.h
@@ -21,11 +21,17 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *const kSDKVersionLoggingParameter;
 extern NSString *const kEnvironmentLoggingParameter;
 
-NSString* GIDVersion(void);
-
-NSString* GIDEnvironment(void);
-
 @interface GIDSignInPreferences : NSObject
+
+/// Returns the current Google Sign-In SDK version, prefixed so that `gid` version values can
+/// be distinguished from other values reported under the legacy `gpsdk` logging key.
++ (NSString *)sdkVersion;
+
+/// Returns the current Apple execution environment, such as `ios` or `macos`.
++ (NSString *)environment;
+
+/// Returns the standard logging parameters to send with requests to Google's servers.
++ (NSDictionary<NSString *, NSString *> *)loggingParameters;
 
 + (NSString *)googleAuthorizationServer;
 + (NSString *)googleTokenServer;

--- a/GoogleSignIn/Sources/GIDSignInPreferences.m
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.m
@@ -44,14 +44,13 @@ static NSString *const kAppleEnvironmentMacOSMacCatalyst = @"macos-cat";
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x
 
-// The prefixed sdk version string to differentiate gid version values used with the legacy gpsdk
-// logging key.
-NSString* GIDVersion(void) {
+@implementation GIDSignInPreferences
+
++ (NSString *)sdkVersion {
   return [NSString stringWithFormat:@"gid-%@", @STR(GID_SDK_VERSION)];
 }
 
-// Get the current Apple execution environment.
-NSString* GIDEnvironment(void) {
++ (NSString *)environment {
   NSString *appleEnvironment = kAppleEnvironmentUnknown;
 
 #if TARGET_OS_MACCATALYST
@@ -80,7 +79,12 @@ NSString* GIDEnvironment(void) {
   return appleEnvironment;
 }
 
-@implementation GIDSignInPreferences
++ (NSDictionary<NSString *, NSString *> *)loggingParameters {
+  return @{
+    kSDKVersionLoggingParameter : [self sdkVersion],
+    kEnvironmentLoggingParameter : [self environment],
+  };
+}
 
 + (NSString *)googleAuthorizationServer {
   return kLSOServer;

--- a/GoogleSignIn/Tests/Unit/GIDSignInPreferencesTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInPreferencesTest.m
@@ -21,13 +21,13 @@
 
 @implementation GIDSignInPreferencesTest
 
-- (void)testGIDVersion {
-  NSString *version = GIDVersion();
+- (void)testSDKVersion {
+  NSString *version = [GIDSignInPreferences sdkVersion];
   XCTAssertTrue([version hasPrefix:@"gid-"]);
 }
 
-- (void)testGIDEnvironment {
-  NSString *environment = GIDEnvironment();
+- (void)testEnvironment {
+  NSString *environment = [GIDSignInPreferences environment];
 
   NSString *expectedEnvironment;
 #if TARGET_OS_MACCATALYST
@@ -42,6 +42,16 @@
   expectedEnvironment = @"macos";
 #endif // TARGET_OS_MACCATALYST
   XCTAssertEqualObjects(environment, expectedEnvironment);
+}
+
+- (void)testLoggingParameters {
+  NSDictionary<NSString *, NSString *> *params = [GIDSignInPreferences loggingParameters];
+
+  XCTAssertEqual(params.count, (NSUInteger)2);
+  XCTAssertEqualObjects(params[kSDKVersionLoggingParameter],
+                        [GIDSignInPreferences sdkVersion]);
+  XCTAssertEqualObjects(params[kEnvironmentLoggingParameter],
+                        [GIDSignInPreferences environment]);
 }
 
 @end

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -1723,9 +1723,11 @@ static NSString *const kMultipleClaimsJsonString =
   NSDictionary<NSString *, NSObject<NSCopying> *> *params = queryComponent.dictionaryValue;
   XCTAssertEqualObjects([params valueForKey:@"token"], token,
                         @"token parameter should match");
-  XCTAssertEqualObjects([params valueForKey:kSDKVersionLoggingParameter], GIDVersion(),
+  XCTAssertEqualObjects([params valueForKey:kSDKVersionLoggingParameter],
+                        [GIDSignInPreferences sdkVersion],
                         @"SDK version logging parameter should match");
-  XCTAssertEqualObjects([params valueForKey:kEnvironmentLoggingParameter], GIDEnvironment(),
+  XCTAssertEqualObjects([params valueForKey:kEnvironmentLoggingParameter],
+                        [GIDSignInPreferences environment],
                         @"Environment logging parameter should match");
   // Emulate result back from server.
   [self didFetch:nil error:nil];
@@ -1891,8 +1893,8 @@ static NSString *const kMultipleClaimsJsonString =
     XCTAssertNotNil(_savedAuthorizationRequest);
     NSDictionary<NSString *, NSObject *> *params = _savedAuthorizationRequest.additionalParameters;
     XCTAssertEqualObjects(params[@"include_granted_scopes"], @"true");
-    XCTAssertEqualObjects(params[kSDKVersionLoggingParameter], GIDVersion());
-    XCTAssertEqualObjects(params[kEnvironmentLoggingParameter], GIDEnvironment());
+    XCTAssertEqualObjects(params[kSDKVersionLoggingParameter], [GIDSignInPreferences sdkVersion]);
+    XCTAssertEqualObjects(params[kEnvironmentLoggingParameter], [GIDSignInPreferences environment]);
     XCTAssertNotNil(_savedAuthorizationCallback);
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
     XCTAssertEqual(_savedPresentingViewController, _presentingViewController);


### PR DESCRIPTION
This PR replaces the GIDVersion() and GIDEnvironment() functions with the `sdkVersion` and `environment` class methods, and adds `loggingParameters` to supply those moved parameters in one place. There is no behaviour change as part of this PR.

It is motivated by the imminent addition of the `gidwrapper` param.