### PR TITLE
Add wrapperIdentifier for callers to self-id in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Add `GIDSignIn.wrapperIdentifier`, an optional identifier that SDKs embedding Google Sign-In can set to self-identify in Google's diagnostic logs via a new `gidwrapper` parameter. The value is sanitized and opt-in; default behavior is unchanged.
+
 # 9.2.0
 - Expose the refresh token expiration date ([#577](https://github.com/google/GoogleSignIn-iOS/pull/577))
 - Support requesting the `amr` (Authentication Methods References) claim ([#600](https://github.com/google/GoogleSignIn-iOS/pull/600))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- Add `GIDSignIn.wrapperIdentifier`, an optional property for SDKs embedding Google Sign-In to self-identify in Google's diagnostic logs via a new `gidwrapper` parameter. It accepts 1-32 characters of lowercase letters, digits and hyphens; non-conforming values are ignored. It is opt-in and default behavior is unchanged.
+- Add `GIDSignIn.wrapperIdentifier`, an optional property for SDKs embedding Google Sign-In to self-identify in Google's diagnostic logs via a new `gidwrapper` parameter. It accepts up to 100 printable ASCII characters; longer values are truncated, and values containing non-ASCII or control characters are dropped. It is opt-in and default behavior is unchanged.
 
 # 9.2.0
 - Expose the refresh token expiration date ([#577](https://github.com/google/GoogleSignIn-iOS/pull/577))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- Add `GIDSignIn.wrapperIdentifier`, an optional identifier that SDKs embedding Google Sign-In can set to self-identify in Google's diagnostic logs via a new `gidwrapper` parameter. The value is sanitized and opt-in; default behavior is unchanged.
+- Add `GIDSignIn.wrapperIdentifier`, an optional property for SDKs embedding Google Sign-In to self-identify in Google's diagnostic logs via a new `gidwrapper` parameter. It accepts 1-32 characters of lowercase letters, digits and hyphens; non-conforming values are ignored. It is opt-in and default behavior is unchanged.
 
 # 9.2.0
 - Expose the refresh token expiration date ([#577](https://github.com/google/GoogleSignIn-iOS/pull/577))

--- a/GoogleSignIn/Sources/GIDGoogleUser.m
+++ b/GoogleSignIn/Sources/GIDGoogleUser.m
@@ -155,6 +155,10 @@ static NSTimeInterval const kMinimalTimeToExpire = 60.0;
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
   additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
+  NSString *wrapperIdentifier = GIDWrapperIdentifier();
+  if (wrapperIdentifier) {
+    additionalParameters[kSDKWrapperLoggingParameter] = wrapperIdentifier;
+  }
 
   OIDTokenRequest *tokenRefreshRequest =
       [self.authState tokenRefreshRequestWithAdditionalParameters:additionalParameters];

--- a/GoogleSignIn/Sources/GIDGoogleUser.m
+++ b/GoogleSignIn/Sources/GIDGoogleUser.m
@@ -153,12 +153,7 @@ static NSTimeInterval const kMinimalTimeToExpire = 60.0;
   [additionalParameters addEntriesFromDictionary:
       self.authState.lastTokenResponse.request.additionalParameters];
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-  additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
-  additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
-  NSString *wrapperIdentifier = GIDWrapperIdentifier();
-  if (wrapperIdentifier) {
-    additionalParameters[kSDKWrapperLoggingParameter] = wrapperIdentifier;
-  }
+  [GIDSignInPreferences addLoggingParameters:additionalParameters];
 
   OIDTokenRequest *tokenRefreshRequest =
       [self.authState tokenRefreshRequestWithAdditionalParameters:additionalParameters];

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -582,6 +582,16 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                      GIDVersion(),
                      kEnvironmentLoggingParameter,
                      GIDEnvironment()];
+  NSString *wrapperIdentifier = GIDWrapperIdentifier();
+  if (wrapperIdentifier) {
+    NSMutableCharacterSet *unreservedSet =
+        [NSMutableCharacterSet alphanumericCharacterSet];
+    [unreservedSet addCharactersInString:@"-._~"];
+    NSString *encodedWrapper = [wrapperIdentifier
+        stringByAddingPercentEncodingWithAllowedCharacters:unreservedSet];
+    revokeURLString = [NSString stringWithFormat:@"%@&%@=%@",
+                       revokeURLString, kSDKWrapperLoggingParameter, encodedWrapper];
+  }
   NSURL *revokeURL = [NSURL URLWithString:revokeURLString];
   [self startFetchURL:revokeURL
               fromAuthState:authState
@@ -623,6 +633,14 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
     }
   });
   return sharedInstance;
+}
+
+- (nullable NSString *)wrapperIdentifier {
+  return GIDWrapperIdentifier();
+}
+
+- (void)setWrapperIdentifier:(nullable NSString *)wrapperIdentifier {
+  GIDSetWrapperIdentifier(wrapperIdentifier);
 }
 
 #pragma mark - Configuring and pre-warming
@@ -921,6 +939,11 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
   additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
   additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
 
+  NSString *wrapperIdentifier = GIDWrapperIdentifier();
+  if (wrapperIdentifier) {
+    additionalParameters[kSDKWrapperLoggingParameter] = wrapperIdentifier;
+  }
+
   return additionalParameters;
 }
 
@@ -1056,6 +1079,11 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
   additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
+
+  NSString *wrapperIdentifier = GIDWrapperIdentifier();
+  if (wrapperIdentifier) {
+    additionalParameters[kSDKWrapperLoggingParameter] = wrapperIdentifier;
+  }
 
   OIDTokenRequest *tokenRequest;
   if (!authState.lastTokenResponse.accessToken &&

--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -573,26 +573,36 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
     }
     return;
   }
-  NSString *revokeURLString = [NSString stringWithFormat:kRevokeTokenURLTemplate,
+  NSString *baseURLString = [NSString stringWithFormat:kRevokeTokenURLTemplate,
       [GIDSignInPreferences googleAuthorizationServer], token];
-  // Append logging parameter
-  revokeURLString = [NSString stringWithFormat:@"%@&%@=%@&%@=%@",
-                     revokeURLString,
-                     kSDKVersionLoggingParameter,
-                     GIDVersion(),
-                     kEnvironmentLoggingParameter,
-                     GIDEnvironment()];
-  NSString *wrapperIdentifier = GIDWrapperIdentifier();
-  if (wrapperIdentifier) {
-    NSMutableCharacterSet *unreservedSet =
-        [NSMutableCharacterSet alphanumericCharacterSet];
-    [unreservedSet addCharactersInString:@"-._~"];
-    NSString *encodedWrapper = [wrapperIdentifier
-        stringByAddingPercentEncodingWithAllowedCharacters:unreservedSet];
-    revokeURLString = [NSString stringWithFormat:@"%@&%@=%@",
-                       revokeURLString, kSDKWrapperLoggingParameter, encodedWrapper];
+  NSURLComponents *components = [NSURLComponents componentsWithString:baseURLString];
+  NSURL *revokeURL;
+  if (components) {
+    NSMutableArray<NSURLQueryItem *> *items =
+        [components.queryItems mutableCopy] ?: [NSMutableArray array];
+
+    NSMutableDictionary<NSString *, NSString *> *loggingParams = [[NSMutableDictionary alloc] init];
+    [GIDSignInPreferences addLoggingParameters:loggingParams];
+    for (NSString *name in [loggingParams.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
+      [items addObject:[NSURLQueryItem queryItemWithName:name value:loggingParams[name]]];
+    }
+
+    components.queryItems = items;
+    revokeURL = components.URL;
   }
-  NSURL *revokeURL = [NSURL URLWithString:revokeURLString];
+
+  if (!revokeURL) {
+    // The revoke URL could not be constructed, so the token was left untouched.
+    NSError *error = [NSError errorWithDomain:kGIDSignInErrorDomain
+                                         code:kGIDSignInErrorCodeUnknown
+                                     userInfo:nil];
+    if (completion) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        completion(error);
+      });
+    }
+    return;
+  }
   [self startFetchURL:revokeURL
               fromAuthState:authState
                 withComment:@"GIDSignIn: revoke tokens"
@@ -636,11 +646,11 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 }
 
 - (nullable NSString *)wrapperIdentifier {
-  return GIDWrapperIdentifier();
+  return [GIDSignInPreferences wrapperIdentifier];
 }
 
 - (void)setWrapperIdentifier:(nullable NSString *)wrapperIdentifier {
-  GIDSetWrapperIdentifier(wrapperIdentifier);
+  [GIDSignInPreferences setWrapperIdentifier:wrapperIdentifier];
 }
 
 #pragma mark - Configuring and pre-warming
@@ -936,13 +946,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
 #elif TARGET_OS_OSX || TARGET_OS_MACCATALYST
   [additionalParameters addEntriesFromDictionary:options.extraParams];
 #endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
-  additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
-  additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
-
-  NSString *wrapperIdentifier = GIDWrapperIdentifier();
-  if (wrapperIdentifier) {
-    additionalParameters[kSDKWrapperLoggingParameter] = wrapperIdentifier;
-  }
+  [GIDSignInPreferences addLoggingParameters:additionalParameters];
 
   return additionalParameters;
 }
@@ -1077,13 +1081,7 @@ static NSString *const kConfigOpenIDRealmKey = @"GIDOpenIDRealm";
                                    emmSupport:authFlow.emmSupport
                        isPasscodeInfoRequired:passcodeInfoRequired.length > 0]];
 #endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-  additionalParameters[kSDKVersionLoggingParameter] = GIDVersion();
-  additionalParameters[kEnvironmentLoggingParameter] = GIDEnvironment();
-
-  NSString *wrapperIdentifier = GIDWrapperIdentifier();
-  if (wrapperIdentifier) {
-    additionalParameters[kSDKWrapperLoggingParameter] = wrapperIdentifier;
-  }
+  [GIDSignInPreferences addLoggingParameters:additionalParameters];
 
   OIDTokenRequest *tokenRequest;
   if (!authState.lastTokenResponse.accessToken &&

--- a/GoogleSignIn/Sources/GIDSignInPreferences.h
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.h
@@ -20,10 +20,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const kSDKVersionLoggingParameter;
 extern NSString *const kEnvironmentLoggingParameter;
+extern NSString *const kSDKWrapperLoggingParameter;
 
 NSString* GIDVersion(void);
 
 NSString* GIDEnvironment(void);
+
+// Returns the sanitized SDK wrapper identifier, or nil if none has been set.
+NSString* _Nullable GIDWrapperIdentifier(void);
+
+// Sets the SDK wrapper identifier. The value is sanitized (see implementation);
+// empty or fully-invalid input clears it. Last write wins. Thread-safe.
+void GIDSetWrapperIdentifier(NSString * _Nullable wrapper);
 
 @interface GIDSignInPreferences : NSObject
 

--- a/GoogleSignIn/Sources/GIDSignInPreferences.h
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.h
@@ -33,10 +33,10 @@ extern NSString *const kSDKWrapperLoggingParameter;
 // Returns the current identifier, or nil if none is set.
 + (nullable NSString *)wrapperIdentifier;
 
-// Sets the SDK wrapper identifier. Valid values are 1-32 characters of [a-z0-9-] with no leading
-// or trailing '-'; invalid input is ignored (and asserts in debug builds). The FIRST valid write
-// wins and later differing writes are ignored (also asserted in debug); passing nil resets the
-// stored value. This method is thread-safe.
+// Sets the SDK wrapper identifier. Values may be up to 100 printable ASCII characters; longer
+// values are truncated to 100; a value containing any non-ASCII or control character, or an empty
+// string, is dropped entirely (and asserts in debug builds); the first accepted write wins and
+// later differing writes are ignored; nil resets; the method is thread-safe.
 + (void)setWrapperIdentifier:(nullable NSString *)wrapperIdentifier;
 
 // Populates the standard logging parameters (gpsdk, gidenv, and gidwrapper when set) on the

--- a/GoogleSignIn/Sources/GIDSignInPreferences.h
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.h
@@ -24,23 +24,31 @@ extern NSString *const kSDKWrapperLoggingParameter;
 
 @interface GIDSignInPreferences : NSObject
 
-// Returns the current Google Sign-In SDK version.
+/// Returns the current Google Sign-In SDK version.
 + (NSString *)sdkVersion;
 
-// Returns the current Apple execution environment (e.g. ios, macos).
+/// Returns the current Apple execution environment, such as `ios` or `macos`.
 + (NSString *)environment;
 
-// Returns the current identifier, or nil if none is set.
+/// Returns the current SDK wrapper identifier, or `nil` if none is set.
 + (nullable NSString *)wrapperIdentifier;
 
-// Sets the SDK wrapper identifier. Values may be up to 100 printable ASCII characters; longer
-// values are truncated to 100; a value containing any non-ASCII or control character, or an empty
-// string, is dropped entirely (and asserts in debug builds); the first accepted write wins and
-// later differing writes are ignored; nil resets; the method is thread-safe.
+/// Sets the SDK wrapper identifier.
+///
+/// A value may be up to 100 printable ASCII characters; a longer value is truncated to its first
+/// 100 characters. A value that is empty, or that contains any non-ASCII or ASCII control
+/// character, is dropped entirely and asserts in debug builds.
+///
+/// The first accepted write wins; later differing writes are ignored. This method is thread-safe.
+///
+/// @param wrapperIdentifier The identifier to report, or `nil` to reset it.
 + (void)setWrapperIdentifier:(nullable NSString *)wrapperIdentifier;
 
-// Populates the standard logging parameters (gpsdk, gidenv, and gidwrapper when set) on the
-// supplied dictionary.
+/// Adds the standard logging parameters to the supplied dictionary.
+///
+/// The parameters are `gpsdk`, `gidenv`, and, when a wrapper identifier is set, `gidwrapper`.
+///
+/// @param params The dictionary to add the logging parameters to.
 + (void)addLoggingParameters:(NSMutableDictionary<NSString *, NSString *> *)params;
 
 + (NSString *)googleAuthorizationServer;

--- a/GoogleSignIn/Sources/GIDSignInPreferences.h
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.h
@@ -22,18 +22,26 @@ extern NSString *const kSDKVersionLoggingParameter;
 extern NSString *const kEnvironmentLoggingParameter;
 extern NSString *const kSDKWrapperLoggingParameter;
 
-NSString* GIDVersion(void);
-
-NSString* GIDEnvironment(void);
-
-// Returns the sanitized SDK wrapper identifier, or nil if none has been set.
-NSString* _Nullable GIDWrapperIdentifier(void);
-
-// Sets the SDK wrapper identifier. The value is sanitized (see implementation);
-// empty or fully-invalid input clears it. Last write wins. Thread-safe.
-void GIDSetWrapperIdentifier(NSString * _Nullable wrapper);
-
 @interface GIDSignInPreferences : NSObject
+
+// Returns the current Google Sign-In SDK version.
++ (NSString *)sdkVersion;
+
+// Returns the current Apple execution environment (e.g. ios, macos).
++ (NSString *)environment;
+
+// Returns the current identifier, or nil if none is set.
++ (nullable NSString *)wrapperIdentifier;
+
+// Sets the SDK wrapper identifier. Valid values are 1-32 characters of [a-z0-9-] with no leading
+// or trailing '-'; invalid input is ignored (and asserts in debug builds). The FIRST valid write
+// wins and later differing writes are ignored (also asserted in debug); passing nil resets the
+// stored value. This method is thread-safe.
++ (void)setWrapperIdentifier:(nullable NSString *)wrapperIdentifier;
+
+// Populates the standard logging parameters (gpsdk, gidenv, and gidwrapper when set) on the
+// supplied dictionary.
++ (void)addLoggingParameters:(NSMutableDictionary<NSString *, NSString *> *)params;
 
 + (NSString *)googleAuthorizationServer;
 + (NSString *)googleTokenServer;

--- a/GoogleSignIn/Sources/GIDSignInPreferences.m
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.m
@@ -14,6 +14,8 @@
 
 #import "GoogleSignIn/Sources/GIDSignInPreferences.h"
 
+#import <os/lock.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kLSOServer = @"accounts.google.com";
@@ -38,15 +40,7 @@ static NSString *const kAppleEnvironmentMacOSIOSOnMac = @"macos-ios";
 static NSString *const kAppleEnvironmentMacOSMacCatalyst = @"macos-cat";
 
 static NSString *gWrapperIdentifier = nil;
-
-static NSObject* GIDWrapperLock(void) {
-  static NSObject *lock;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    lock = [[NSObject alloc] init];
-  });
-  return lock;
-}
+static os_unfair_lock gWrapperIdentifierLock = OS_UNFAIR_LOCK_INIT;
 
 #ifndef GID_SDK_VERSION
 #error "GID_SDK_VERSION is not defined: add -DGID_SDK_VERSION=x.x.x to the build invocation."
@@ -58,14 +52,35 @@ static NSObject* GIDWrapperLock(void) {
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x
 
-// The prefixed sdk version string to differentiate gid version values used with the legacy gpsdk
-// logging key.
-NSString* GIDVersion(void) {
+static BOOL GIDIsValidWrapperIdentifier(NSString * _Nullable candidate) {
+  if (candidate == nil) {
+    return NO;
+  }
+
+  if (candidate.length == 0 || candidate.length > 32) {
+    return NO;
+  }
+
+  NSCharacterSet *allowed =
+      [NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyz0123456789-"];
+  if ([candidate rangeOfCharacterFromSet:[allowed invertedSet]].location != NSNotFound) {
+    return NO;
+  }
+
+  if ([candidate hasPrefix:@"-"] || [candidate hasSuffix:@"-"]) {
+    return NO;
+  }
+
+  return YES;
+}
+
+@implementation GIDSignInPreferences
+
++ (NSString *)sdkVersion {
   return [NSString stringWithFormat:@"gid-%@", @STR(GID_SDK_VERSION)];
 }
 
-// Get the current Apple execution environment.
-NSString* GIDEnvironment(void) {
++ (NSString *)environment {
   NSString *appleEnvironment = kAppleEnvironmentUnknown;
 
 #if TARGET_OS_MACCATALYST
@@ -94,54 +109,51 @@ NSString* GIDEnvironment(void) {
   return appleEnvironment;
 }
 
-static NSString * _Nullable GIDSanitizeWrapperIdentifier(NSString * _Nullable raw) {
-  if (!raw) {
-    return nil;
-  }
-
-  // Trim leading/trailing whitespace and newlines.
-  NSString *sanitized = [raw stringByTrimmingCharactersInSet:
-      [NSCharacterSet whitespaceAndNewlineCharacterSet]];
-  if (sanitized.length == 0) {
-    return nil;
-  }
-
-  // Lowercase (locale-independent).
-  sanitized = [sanitized lowercaseString];
-
-  // Keep only characters in the allowlist [A-Za-z0-9-._~]; drop everything else.
-  NSCharacterSet *allowed =
-      [NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyz0123456789-._~"];
-  sanitized = [[sanitized componentsSeparatedByCharactersInSet:[allowed invertedSet]]
-      componentsJoinedByString:@""];
-
-  if (sanitized.length == 0) {
-    return nil;
-  }
-
-  // If length > 32, take substringToIndex:32.
-  // Safe because the allowlist is ASCII, so each character is exactly one UTF-16 unit.
-  if (sanitized.length > 32) {
-    sanitized = [sanitized substringToIndex:32];
-  }
-
-  return sanitized;
++ (nullable NSString *)wrapperIdentifier {
+  os_unfair_lock_lock(&gWrapperIdentifierLock);
+  NSString *wrapper = [gWrapperIdentifier copy];
+  os_unfair_lock_unlock(&gWrapperIdentifierLock);
+  return wrapper;
 }
 
-NSString* GIDWrapperIdentifier(void) {
-  @synchronized(GIDWrapperLock()) {
-    return [gWrapperIdentifier copy];
++ (void)setWrapperIdentifier:(nullable NSString *)wrapperIdentifier {
+  if (wrapperIdentifier == nil) {
+    os_unfair_lock_lock(&gWrapperIdentifierLock);
+    gWrapperIdentifier = nil;
+    os_unfair_lock_unlock(&gWrapperIdentifierLock);
+    return;
   }
+
+  if (!GIDIsValidWrapperIdentifier(wrapperIdentifier)) {
+#if DEBUG
+    NSAssert(NO, @"SDK wrapper '%@' rejected: must be 1-32 characters of [a-z0-9-] with no "
+                 @"leading or trailing '-'. Value ignored.", wrapperIdentifier);
+#endif
+    return;
+  }
+
+  os_unfair_lock_lock(&gWrapperIdentifierLock);
+  NSString *current = gWrapperIdentifier;
+  if (current != nil && ![current isEqualToString:wrapperIdentifier]) {
+    os_unfair_lock_unlock(&gWrapperIdentifierLock);
+#if DEBUG
+    NSAssert(NO, @"SDK wrapper already set to '%@'; ignoring '%@'. More than one "
+                 @"wrapper appears to be present.", current, wrapperIdentifier);
+#endif
+    return;
+  }
+  gWrapperIdentifier = [wrapperIdentifier copy];
+  os_unfair_lock_unlock(&gWrapperIdentifierLock);
 }
 
-void GIDSetWrapperIdentifier(NSString * _Nullable wrapper) {
-  NSString *sanitized = GIDSanitizeWrapperIdentifier(wrapper);
-  @synchronized(GIDWrapperLock()) {
-    gWrapperIdentifier = [sanitized copy];
++ (void)addLoggingParameters:(NSMutableDictionary<NSString *, NSString *> *)params {
+  params[kSDKVersionLoggingParameter] = [self sdkVersion];
+  params[kEnvironmentLoggingParameter] = [self environment];
+  NSString *wrapper = [self wrapperIdentifier];
+  if (wrapper != nil) {
+    params[kSDKWrapperLoggingParameter] = wrapper;
   }
 }
-
-@implementation GIDSignInPreferences
 
 + (NSString *)googleAuthorizationServer {
   return kLSOServer;

--- a/GoogleSignIn/Sources/GIDSignInPreferences.m
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.m
@@ -52,26 +52,35 @@ static os_unfair_lock gWrapperIdentifierLock = OS_UNFAIR_LOCK_INIT;
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x
 
-static BOOL GIDIsValidWrapperIdentifier(NSString * _Nullable candidate) {
-  if (candidate == nil) {
-    return NO;
+// Returns the sanitized form of `candidate`, or nil if it must be dropped.
+// Callers must not pass nil.
+static NSString * _Nullable GIDSanitizedWrapperIdentifier(NSString *candidate) {
+  static NSCharacterSet *allowedSet;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    // The range of printable ASCII characters is U+0020 through U+007E inclusive.
+    allowedSet = [NSCharacterSet characterSetWithRange:NSMakeRange(0x20, 0x5F)];
+  });
+
+  // DROP CHECK FIRST: if it contains any character outside the printable ASCII range, drop it.
+  if ([candidate rangeOfCharacterFromSet:[allowedSet invertedSet]].location != NSNotFound) {
+    return nil;
   }
 
-  if (candidate.length == 0 || candidate.length > 32) {
-    return NO;
+  // An empty string is also discarded.
+  if (candidate.length == 0) {
+    return nil;
   }
 
-  NSCharacterSet *allowed =
-      [NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyz0123456789-"];
-  if ([candidate rangeOfCharacterFromSet:[allowed invertedSet]].location != NSNotFound) {
-    return NO;
+  // TRUNCATE SECOND: A surviving string longer than 100 characters is truncated to 100.
+  if (candidate.length > 100) {
+    // Truncating with -substringToIndex:100 is safe here precisely because the drop check has
+    // already guaranteed every character is single-unit ASCII, so there is no risk of splitting
+    // a surrogate pair.
+    return [candidate substringToIndex:100];
   }
 
-  if ([candidate hasPrefix:@"-"] || [candidate hasSuffix:@"-"]) {
-    return NO;
-  }
-
-  return YES;
+  return candidate;
 }
 
 @implementation GIDSignInPreferences
@@ -124,25 +133,26 @@ static BOOL GIDIsValidWrapperIdentifier(NSString * _Nullable candidate) {
     return;
   }
 
-  if (!GIDIsValidWrapperIdentifier(wrapperIdentifier)) {
+  NSString *sanitized = GIDSanitizedWrapperIdentifier(wrapperIdentifier);
+  if (sanitized == nil) {
 #if DEBUG
-    NSAssert(NO, @"SDK wrapper '%@' rejected: must be 1-32 characters of [a-z0-9-] with no "
-                 @"leading or trailing '-'. Value ignored.", wrapperIdentifier);
+    NSAssert(NO, @"SDK wrapper '%@' rejected: must not be empty and must only contain printable "
+                 @"ASCII characters (U+0020 to U+007E). Value ignored.", wrapperIdentifier);
 #endif
     return;
   }
 
   os_unfair_lock_lock(&gWrapperIdentifierLock);
   NSString *current = gWrapperIdentifier;
-  if (current != nil && ![current isEqualToString:wrapperIdentifier]) {
+  if (current != nil && ![current isEqualToString:sanitized]) {
     os_unfair_lock_unlock(&gWrapperIdentifierLock);
 #if DEBUG
     NSAssert(NO, @"SDK wrapper already set to '%@'; ignoring '%@'. More than one "
-                 @"wrapper appears to be present.", current, wrapperIdentifier);
+                 @"wrapper appears to be present.", current, sanitized);
 #endif
     return;
   }
-  gWrapperIdentifier = [wrapperIdentifier copy];
+  gWrapperIdentifier = [sanitized copy];
   os_unfair_lock_unlock(&gWrapperIdentifierLock);
 }
 

--- a/GoogleSignIn/Sources/GIDSignInPreferences.m
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.m
@@ -26,6 +26,9 @@ NSString *const kSDKVersionLoggingParameter = @"gpsdk";
 // The name of the query parameter used for logging the Apple execution environment.
 NSString *const kEnvironmentLoggingParameter = @"gidenv";
 
+// The name of the query parameter used to log the embedding SDK / wrapper.
+NSString *const kSDKWrapperLoggingParameter = @"gidwrapper";
+
 // Supported Apple execution environments
 static NSString *const kAppleEnvironmentUnknown = @"unknown";
 static NSString *const kAppleEnvironmentIOS = @"ios";
@@ -33,6 +36,17 @@ static NSString *const kAppleEnvironmentIOSSimulator = @"ios-sim";
 static NSString *const kAppleEnvironmentMacOS = @"macos";
 static NSString *const kAppleEnvironmentMacOSIOSOnMac = @"macos-ios";
 static NSString *const kAppleEnvironmentMacOSMacCatalyst = @"macos-cat";
+
+static NSString *gWrapperIdentifier = nil;
+
+static NSObject* GIDWrapperLock(void) {
+  static NSObject *lock;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    lock = [[NSObject alloc] init];
+  });
+  return lock;
+}
 
 #ifndef GID_SDK_VERSION
 #error "GID_SDK_VERSION is not defined: add -DGID_SDK_VERSION=x.x.x to the build invocation."
@@ -78,6 +92,53 @@ NSString* GIDEnvironment(void) {
 #endif // TARGET_OS_MACCATALYST
 
   return appleEnvironment;
+}
+
+static NSString * _Nullable GIDSanitizeWrapperIdentifier(NSString * _Nullable raw) {
+  if (!raw) {
+    return nil;
+  }
+
+  // Trim leading/trailing whitespace and newlines.
+  NSString *sanitized = [raw stringByTrimmingCharactersInSet:
+      [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+  if (sanitized.length == 0) {
+    return nil;
+  }
+
+  // Lowercase (locale-independent).
+  sanitized = [sanitized lowercaseString];
+
+  // Keep only characters in the allowlist [A-Za-z0-9-._~]; drop everything else.
+  NSCharacterSet *allowed =
+      [NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyz0123456789-._~"];
+  sanitized = [[sanitized componentsSeparatedByCharactersInSet:[allowed invertedSet]]
+      componentsJoinedByString:@""];
+
+  if (sanitized.length == 0) {
+    return nil;
+  }
+
+  // If length > 32, take substringToIndex:32.
+  // Safe because the allowlist is ASCII, so each character is exactly one UTF-16 unit.
+  if (sanitized.length > 32) {
+    sanitized = [sanitized substringToIndex:32];
+  }
+
+  return sanitized;
+}
+
+NSString* GIDWrapperIdentifier(void) {
+  @synchronized(GIDWrapperLock()) {
+    return [gWrapperIdentifier copy];
+  }
+}
+
+void GIDSetWrapperIdentifier(NSString * _Nullable wrapper) {
+  NSString *sanitized = GIDSanitizeWrapperIdentifier(wrapper);
+  @synchronized(GIDWrapperLock()) {
+    gWrapperIdentifier = [sanitized copy];
+  }
 }
 
 @implementation GIDSignInPreferences

--- a/GoogleSignIn/Sources/GIDSignInPreferences.m
+++ b/GoogleSignIn/Sources/GIDSignInPreferences.m
@@ -62,7 +62,8 @@ static NSString * _Nullable GIDSanitizedWrapperIdentifier(NSString *candidate) {
     allowedSet = [NSCharacterSet characterSetWithRange:NSMakeRange(0x20, 0x5F)];
   });
 
-  // DROP CHECK FIRST: if it contains any character outside the printable ASCII range, drop it.
+  // The drop check happens before truncation: if the original string contains any character
+  // outside the printable ASCII range, we drop the entire value.
   if ([candidate rangeOfCharacterFromSet:[allowedSet invertedSet]].location != NSNotFound) {
     return nil;
   }
@@ -72,7 +73,7 @@ static NSString * _Nullable GIDSanitizedWrapperIdentifier(NSString *candidate) {
     return nil;
   }
 
-  // TRUNCATE SECOND: A surviving string longer than 100 characters is truncated to 100.
+  // A surviving string longer than 100 characters is truncated to 100.
   if (candidate.length > 100) {
     // Truncating with -substringToIndex:100 is safe here precisely because the drop check has
     // already guaranteed every character is single-unit ASCII, so there is no risk of splitting

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -77,9 +77,10 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 /// reported to Google as a diagnostic parameter for aggregate metrics only; it
 /// is never used for authentication or authorization.
 ///
-/// Format: 1 to 32 characters, lowercase letters, digits and hyphens only, not
-/// starting or ending with a hyphen. Non-conforming values are ignored and
-/// assert in debug builds.
+/// Format: up to 100 printable ASCII characters (U+0020 to U+007E). A longer
+/// value is truncated to its first 100 characters. A value containing any
+/// non-ASCII character or any ASCII control character is dropped in its
+/// entirety, and asserts in debug builds.
 ///
 /// Policy:
 /// * Choose one stable name and keep it stable across your releases.

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -73,6 +73,14 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 /// The active configuration for this instance of `GIDSignIn`.
 @property(nonatomic, nullable) GIDConfiguration *configuration;
 
+/// An optional identifier naming the SDK or wrapper that embeds Google Sign-In.
+/// Reported to Google as a diagnostic logging parameter for aggregate metrics only;
+/// it is never used for authentication or authorization. Set this once, before your
+/// first sign-in call. The value is sanitized: lowercased, restricted to the
+/// characters A-Z a-z 0-9 - . _ ~, and capped at 32 characters; input that does not
+/// conform is truncated or ignored.
+@property(nonatomic, nullable) NSString *wrapperIdentifier;
+
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 /// Configures `GIDSignIn` for use.

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -73,12 +73,23 @@ typedef NS_ERROR_ENUM(kGIDSignInErrorDomain, GIDSignInErrorCode) {
 /// The active configuration for this instance of `GIDSignIn`.
 @property(nonatomic, nullable) GIDConfiguration *configuration;
 
-/// An optional identifier naming the SDK or wrapper that embeds Google Sign-In.
-/// Reported to Google as a diagnostic logging parameter for aggregate metrics only;
-/// it is never used for authentication or authorization. Set this once, before your
-/// first sign-in call. The value is sanitized: lowercased, restricted to the
-/// characters A-Z a-z 0-9 - . _ ~, and capped at 32 characters; input that does not
-/// conform is truncated or ignored.
+/// An optional identifier naming the SDK or wrapper that embeds Google Sign-In,
+/// reported to Google as a diagnostic parameter for aggregate metrics only; it
+/// is never used for authentication or authorization.
+///
+/// Format: 1 to 32 characters, lowercase letters, digits and hyphens only, not
+/// starting or ending with a hyphen. Non-conforming values are ignored and
+/// assert in debug builds.
+///
+/// Policy:
+/// * Choose one stable name and keep it stable across your releases.
+/// * Do NOT encode your version in it; per-release identifiers make aggregate
+///   metrics useless.
+/// * Never include anything user-specific, app-specific, or identifying.
+/// * Register your identifier with Google before shipping it.
+///
+/// Set this once, before your first sign-in call. The first valid value wins;
+/// later differing values are ignored.
 @property(nonatomic, nullable) NSString *wrapperIdentifier;
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
@@ -536,9 +536,9 @@ static NSString *const kNewScope = @"newScope";
   [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)testWrapperIdentifier_AbsentOnRefreshRequestWhenInvalid {
-  // Assert that attempting to set an invalid identifier throws NSInternalInconsistencyException.
-  XCTAssertThrowsSpecificNamed(GIDSignIn.sharedInstance.wrapperIdentifier = @"Fire Base!",
+- (void)testWrapperIdentifier_AbsentOnRefreshRequestWhenDropped {
+  // Assert that attempting to set a dropped identifier throws NSInternalInconsistencyException.
+  XCTAssertThrowsSpecificNamed(GIDSignIn.sharedInstance.wrapperIdentifier = @"firebasé",
                                NSException, NSInternalInconsistencyException);
 
   // The rejection leaves the store nil.

--- a/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
@@ -23,6 +23,7 @@
 #import "GoogleSignIn/Sources/Public/GoogleSignIn/GIDToken.h"
 
 #import "GoogleSignIn/Sources/GIDGoogleUser_Private.h"
+#import "GoogleSignIn/Sources/GIDSignInPreferences.h"
 #import "GoogleSignIn/Tests/Unit/GIDGoogleUser+Testing.h"
 #import "GoogleSignIn/Tests/Unit/GIDProfileData+Testing.h"
 #import "GoogleSignIn/Tests/Unit/OIDAuthState+Testing.h"
@@ -67,10 +68,13 @@ static NSString *const kNewScope = @"newScope";
 @implementation GIDGoogleUserTest {
   // The saved token fetch handler.
   OIDTokenCallback _tokenFetchHandler;
+  // The saved token request.
+  OIDTokenRequest *_savedTokenRequest;
 }
 
 - (void)setUp {
   _tokenFetchHandler = nil;
+  _savedTokenRequest = nil;
   
   // We need to use swizzle here because OCMock can not stub class method with arguments.
   [GULSwizzler swizzleClass:[OIDAuthorizationService class]
@@ -80,7 +84,8 @@ static NSString *const kNewScope = @"newScope";
                               OIDTokenRequest *request,
                               OIDAuthorizationResponse *authorizationResponse,
                               OIDTokenCallback callback) {
-    // Save the OIDTokenCallback.
+    // Save the OIDTokenRequest and OIDTokenCallback.
+    self->_savedTokenRequest = request;
     self->_tokenFetchHandler = [callback copy];
   }];
 }
@@ -89,6 +94,7 @@ static NSString *const kNewScope = @"newScope";
   [GULSwizzler unswizzleClass:[OIDAuthorizationService class]
                      selector:@selector(performTokenRequest:originalAuthorizationResponse:callback:)
               isClassSelector:YES];
+  GIDSignIn.sharedInstance.wrapperIdentifier = nil;
 }
 
 #pragma mark - Tests
@@ -475,6 +481,58 @@ static NSString *const kNewScope = @"newScope";
     XCTAssertEqual(error.code, kGIDSignInErrorCodeRefreshTokenExpired);
   }];
     
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testWrapperIdentifier_PresentOnRefreshRequestWhenSet {
+  GIDSignIn.sharedInstance.wrapperIdentifier = @"firebase";
+
+  // Both tokens expired 10 seconds ago.
+  GIDGoogleUser *user = [self googleUserWithAccessTokenExpiresIn:-10 idTokenExpiresIn:-10];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Callback is called"];
+
+  // Save the intermediate states.
+  [user refreshTokensIfNeededWithCompletion:^(GIDGoogleUser * _Nullable user,
+                                              NSError * _Nullable error) {
+    [expectation fulfill];
+  }];
+
+  XCTAssertEqualObjects(_savedTokenRequest.additionalParameters[@"gidwrapper"], @"firebase");
+
+  // Clean up the handler by providing a fake response to fulfill any internal state.
+  OIDTokenResponse *fakeResponse = [OIDTokenResponse testInstanceWithIDToken:nil
+                                                                 accessToken:kNewAccessToken
+                                                                   expiresIn:@(kAccessTokenExpiresIn)
+                                                                refreshToken:kRefreshToken
+                                                                tokenRequest:_savedTokenRequest];
+  _tokenFetchHandler(fakeResponse, nil);
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testWrapperIdentifier_AbsentOnRefreshRequestWhenUnset {
+  GIDSignIn.sharedInstance.wrapperIdentifier = nil;
+
+  // Both tokens expired 10 seconds ago.
+  GIDGoogleUser *user = [self googleUserWithAccessTokenExpiresIn:-10 idTokenExpiresIn:-10];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Callback is called"];
+
+  // Save the intermediate states.
+  [user refreshTokensIfNeededWithCompletion:^(GIDGoogleUser * _Nullable user,
+                                              NSError * _Nullable error) {
+    [expectation fulfill];
+  }];
+
+  XCTAssertNil(_savedTokenRequest.additionalParameters[@"gidwrapper"]);
+
+  // Clean up the handler by providing a fake response.
+  OIDTokenResponse *fakeResponse = [OIDTokenResponse testInstanceWithIDToken:nil
+                                                                 accessToken:kNewAccessToken
+                                                                   expiresIn:@(kAccessTokenExpiresIn)
+                                                                refreshToken:kRefreshToken
+                                                                tokenRequest:_savedTokenRequest];
+  _tokenFetchHandler(fakeResponse, nil);
   [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 

--- a/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDGoogleUserTest.m
@@ -536,6 +536,44 @@ static NSString *const kNewScope = @"newScope";
   [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)testWrapperIdentifier_AbsentOnRefreshRequestWhenInvalid {
+  // Assert that attempting to set an invalid identifier throws NSInternalInconsistencyException.
+  XCTAssertThrowsSpecificNamed(GIDSignIn.sharedInstance.wrapperIdentifier = @"Fire Base!",
+                               NSException, NSInternalInconsistencyException);
+
+  // The rejection leaves the store nil.
+  XCTAssertNil(GIDSignIn.sharedInstance.wrapperIdentifier);
+
+  // Both tokens expired 10 seconds ago.
+  GIDGoogleUser *user = [self googleUserWithAccessTokenExpiresIn:-10 idTokenExpiresIn:-10];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Callback is called"];
+
+  // Save the intermediate states.
+  [user refreshTokensIfNeededWithCompletion:^(GIDGoogleUser * _Nullable user,
+                                              NSError * _Nullable error) {
+    [expectation fulfill];
+  }];
+
+  // Assert the captured token request additionalParameters does NOT contain key @"gidwrapper".
+  XCTAssertNil(_savedTokenRequest.additionalParameters[@"gidwrapper"]);
+
+  // Assert it DOES contain kSDKVersionLoggingParameter and kEnvironmentLoggingParameter.
+  XCTAssertEqualObjects(_savedTokenRequest.additionalParameters[kSDKVersionLoggingParameter],
+                        [GIDSignInPreferences sdkVersion]);
+  XCTAssertEqualObjects(_savedTokenRequest.additionalParameters[kEnvironmentLoggingParameter],
+                        [GIDSignInPreferences environment]);
+
+  // Clean up the handler by providing a fake response.
+  OIDTokenResponse *fakeResponse = [OIDTokenResponse testInstanceWithIDToken:nil
+                                                                 accessToken:kNewAccessToken
+                                                                   expiresIn:@(kAccessTokenExpiresIn)
+                                                                refreshToken:kRefreshToken
+                                                                tokenRequest:_savedTokenRequest];
+  _tokenFetchHandler(fakeResponse, nil);
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
 # pragma mark - Test `addScopes:`
 
 - (void)testAddScopes_success {

--- a/GoogleSignIn/Tests/Unit/GIDSignInPreferencesTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInPreferencesTest.m
@@ -44,4 +44,75 @@
   XCTAssertEqualObjects(environment, expectedEnvironment);
 }
 
+- (void)tearDown {
+  GIDSetWrapperIdentifier(nil);
+  [super tearDown];
+}
+
+- (void)testWrapperIdentifier_UnsetReturnsNil {
+  // Test that when no identifier is set (or it is explicitly cleared), nil is returned.
+  GIDSetWrapperIdentifier(nil);
+  XCTAssertNil(GIDWrapperIdentifier());
+}
+
+- (void)testWrapperIdentifier_RoundTripsSimpleValue {
+  // Test that a simple alphanumeric identifier is correctly stored and retrieved.
+  GIDSetWrapperIdentifier(@"firebase");
+  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"firebase");
+}
+
+- (void)testWrapperIdentifier_Lowercases {
+  // Test that identifiers are automatically lowercased when stored.
+  GIDSetWrapperIdentifier(@"FireBase");
+  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"firebase");
+}
+
+- (void)testWrapperIdentifier_StripsDisallowedCharacters {
+  // Test that spaces and disallowed punctuation are removed from the identifier.
+  GIDSetWrapperIdentifier(@"fire base!/&=?");
+  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"firebase");
+}
+
+- (void)testWrapperIdentifier_KeepsAllowedPunctuation {
+  // Test that allowed characters (A-Za-z0-9-._~) are preserved.
+  GIDSetWrapperIdentifier(@"my-sdk_1.2~x");
+  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"my-sdk_1.2~x");
+}
+
+- (void)testWrapperIdentifier_TrimsWhitespace {
+  // Test that leading and trailing whitespace is trimmed from the identifier.
+  GIDSetWrapperIdentifier(@"  firebase  ");
+  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"firebase");
+}
+
+- (void)testWrapperIdentifier_EmptyOrWhitespaceBecomesNil {
+  // Test that empty or whitespace-only strings result in a nil identifier.
+  GIDSetWrapperIdentifier(@"   ");
+  XCTAssertNil(GIDWrapperIdentifier());
+
+  // Test that a string consisting only of invalid characters results in a nil identifier.
+  GIDSetWrapperIdentifier(@"!!!");
+  XCTAssertNil(GIDWrapperIdentifier());
+}
+
+- (void)testWrapperIdentifier_CapsAtThirtyTwoCharacters {
+  // Test that the identifier is truncated to a maximum of 32 characters.
+  NSString *longString = @"abcdefghijklmnopqrstuvwxyz1234567890"; // 36 characters
+  GIDSetWrapperIdentifier(longString);
+  NSString *result = GIDWrapperIdentifier();
+  XCTAssertEqual(result.length, (NSUInteger)32);
+  XCTAssertEqualObjects(result, [longString.lowercaseString substringToIndex:32]);
+}
+
+- (void)testWrapperIdentifier_LastWriteWins {
+  // Test that subsequent writes overwrite the previous identifier.
+  GIDSetWrapperIdentifier(@"first");
+  GIDSetWrapperIdentifier(@"second");
+  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"second");
+
+  // Test that setting it to nil clears the identifier.
+  GIDSetWrapperIdentifier(nil);
+  XCTAssertNil(GIDWrapperIdentifier());
+}
+
 @end

--- a/GoogleSignIn/Tests/Unit/GIDSignInPreferencesTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInPreferencesTest.m
@@ -74,75 +74,23 @@
 }
 
 - (void)testWrapperIdentifier_AcceptsMaximumLength {
-  // Test that a 32-character valid identifier is accepted and not truncated.
-  NSString *maxLength = @"abcdefghijklmnopqrstuvwxyz123456"; // 32 chars
+  // Test that a 100-character valid identifier is accepted and not truncated.
+  NSString *maxLength = [@"a" stringByPaddingToLength:100 withString:@"a" startingAtIndex:0];
   [GIDSignInPreferences setWrapperIdentifier:maxLength];
-  XCTAssertEqual([GIDSignInPreferences wrapperIdentifier].length, (NSUInteger)32);
+  XCTAssertEqual([GIDSignInPreferences wrapperIdentifier].length, (NSUInteger)100);
   XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], maxLength);
 }
 
-- (void)testWrapperIdentifier_RejectsUppercase {
-  // Test that uppercase characters cause a rejection.
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"Firebase"],
-                               NSException,
-                               NSInternalInconsistencyException);
-  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+- (void)testWrapperIdentifier_AcceptsMixedCaseSpacesAndPunctuation {
+  // Test that mixed case, spaces and punctuation are accepted.
+  NSString *value = @"React Native SDK (v2.0)";
+  [GIDSignInPreferences setWrapperIdentifier:value];
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], value);
 }
 
-- (void)testWrapperIdentifier_RejectsWhitespace {
-  // Test that leading/trailing or internal whitespace cause a rejection.
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"  firebase  "],
-                               NSException,
-                               NSInternalInconsistencyException);
-  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
-
-  [GIDSignInPreferences setWrapperIdentifier:nil];
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"fire base"],
-                               NSException,
-                               NSInternalInconsistencyException);
-  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
-}
-
-- (void)testWrapperIdentifier_RejectsPunctuation {
-  // Test that disallowed punctuation causes a rejection.
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"my-sdk_1.2~x"],
-                               NSException,
-                               NSInternalInconsistencyException);
-  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
-
-  [GIDSignInPreferences setWrapperIdentifier:nil];
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"fire!base"],
-                               NSException,
-                               NSInternalInconsistencyException);
-  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
-}
-
-- (void)testWrapperIdentifier_RejectsEmpty {
-  // Test that an empty string is rejected.
+- (void)testWrapperIdentifier_DropsEmptyString {
+  // Test that an empty string is dropped.
   XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@""],
-                               NSException,
-                               NSInternalInconsistencyException);
-  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
-}
-
-- (void)testWrapperIdentifier_RejectsOverLength {
-  // Test that a 33-character identifier is rejected.
-  NSString *overLength = @"abcdefghijklmnopqrstuvwxyz1234567"; // 33 chars
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:overLength],
-                               NSException,
-                               NSInternalInconsistencyException);
-  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
-}
-
-- (void)testWrapperIdentifier_RejectsLeadingOrTrailingHyphen {
-  // Test that leading or trailing hyphens cause a rejection.
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"-sdk"],
-                               NSException,
-                               NSInternalInconsistencyException);
-  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
-
-  [GIDSignInPreferences setWrapperIdentifier:nil];
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"sdk-"],
                                NSException,
                                NSInternalInconsistencyException);
   XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
@@ -174,13 +122,71 @@
   XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"second");
 }
 
-- (void)testWrapperIdentifier_RejectedWriteLeavesPreviousValue {
-  // Test that a rejected write does not clear or change a previously set valid value.
+- (void)testWrapperIdentifier_DroppedWriteLeavesPreviousValue {
+  // Test that a dropped write does not clear or change a previously set valid value.
   [GIDSignInPreferences setWrapperIdentifier:@"firebase"];
-  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"Invalid!"],
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"firebasé"],
                                NSException,
                                NSInternalInconsistencyException);
   XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"firebase");
+}
+
+- (void)testWrapperIdentifier_TruncatesOverLongValue {
+  // Test that a legal string longer than 100 characters is truncated to its first 100 characters.
+  NSString *overLong = [@"a" stringByPaddingToLength:150 withString:@"a" startingAtIndex:0];
+  XCTAssertNoThrow([GIDSignInPreferences setWrapperIdentifier:overLong]);
+  XCTAssertEqual([GIDSignInPreferences wrapperIdentifier].length, (NSUInteger)100);
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], [overLong substringToIndex:100]);
+}
+
+- (void)testWrapperIdentifier_DropsNonASCII {
+  // Test that a value containing a non-ASCII character throws and leaves the store nil.
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"firebasé"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+}
+
+- (void)testWrapperIdentifier_DropsControlCharacters {
+  // Test that values containing ASCII control characters throw and leave the store nil.
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"fire\nbase"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+
+  [GIDSignInPreferences setWrapperIdentifier:nil];
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"fire\tbase"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+
+  [GIDSignInPreferences setWrapperIdentifier:nil];
+  NSString *del = [NSString stringWithFormat:@"fire%Cbase", (unichar)0x7F];
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:del],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+}
+
+- (void)testWrapperIdentifier_DropsWhenDisallowedCharacterIsPastTruncationPoint {
+  // Test that the drop check deliberately runs on the untruncated string so a payload hidden
+  // past the truncation point cannot survive.
+  NSString *prefix = [@"a" stringByPaddingToLength:120 withString:@"a" startingAtIndex:0];
+  NSString *overLong = [prefix stringByReplacingCharactersInRange:NSMakeRange(110, 1)
+                                                       withString:@"é"];
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:overLong],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+}
+
+- (void)testWrapperIdentifier_WriteOnceComparesSanitizedValue {
+  // Test that the write-once check compares the sanitized value, allowing a repeated
+  // write of a value that truncates to the same result.
+  NSString *overLong = [@"a" stringByPaddingToLength:150 withString:@"a" startingAtIndex:0];
+  [GIDSignInPreferences setWrapperIdentifier:overLong];
+  XCTAssertNoThrow([GIDSignInPreferences setWrapperIdentifier:overLong]);
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], [overLong substringToIndex:100]);
 }
 
 @end

--- a/GoogleSignIn/Tests/Unit/GIDSignInPreferencesTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInPreferencesTest.m
@@ -22,12 +22,12 @@
 @implementation GIDSignInPreferencesTest
 
 - (void)testGIDVersion {
-  NSString *version = GIDVersion();
+  NSString *version = [GIDSignInPreferences sdkVersion];
   XCTAssertTrue([version hasPrefix:@"gid-"]);
 }
 
 - (void)testGIDEnvironment {
-  NSString *environment = GIDEnvironment();
+  NSString *environment = [GIDSignInPreferences environment];
 
   NSString *expectedEnvironment;
 #if TARGET_OS_MACCATALYST
@@ -45,74 +45,142 @@
 }
 
 - (void)tearDown {
-  GIDSetWrapperIdentifier(nil);
+  [GIDSignInPreferences setWrapperIdentifier:nil];
   [super tearDown];
 }
 
-- (void)testWrapperIdentifier_UnsetReturnsNil {
-  // Test that when no identifier is set (or it is explicitly cleared), nil is returned.
-  GIDSetWrapperIdentifier(nil);
-  XCTAssertNil(GIDWrapperIdentifier());
+- (void)testWrapperIdentifier_UnsetIsNil {
+  // Test that when no identifier is set, nil is returned.
+  [GIDSignInPreferences setWrapperIdentifier:nil];
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
 }
 
-- (void)testWrapperIdentifier_RoundTripsSimpleValue {
-  // Test that a simple alphanumeric identifier is correctly stored and retrieved.
-  GIDSetWrapperIdentifier(@"firebase");
-  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"firebase");
+- (void)testWrapperIdentifier_AcceptsSimpleValue {
+  // Test that a simple lowercase alphanumeric identifier is accepted.
+  [GIDSignInPreferences setWrapperIdentifier:@"firebase"];
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"firebase");
 }
 
-- (void)testWrapperIdentifier_Lowercases {
-  // Test that identifiers are automatically lowercased when stored.
-  GIDSetWrapperIdentifier(@"FireBase");
-  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"firebase");
+- (void)testWrapperIdentifier_AcceptsHyphenatedValue {
+  // Test that a value with internal hyphens is accepted.
+  [GIDSignInPreferences setWrapperIdentifier:@"react-native"];
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"react-native");
 }
 
-- (void)testWrapperIdentifier_StripsDisallowedCharacters {
-  // Test that spaces and disallowed punctuation are removed from the identifier.
-  GIDSetWrapperIdentifier(@"fire base!/&=?");
-  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"firebase");
+- (void)testWrapperIdentifier_AcceptsDigits {
+  // Test that a value with digits is accepted.
+  [GIDSignInPreferences setWrapperIdentifier:@"wrapper2"];
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"wrapper2");
 }
 
-- (void)testWrapperIdentifier_KeepsAllowedPunctuation {
-  // Test that allowed characters (A-Za-z0-9-._~) are preserved.
-  GIDSetWrapperIdentifier(@"my-sdk_1.2~x");
-  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"my-sdk_1.2~x");
+- (void)testWrapperIdentifier_AcceptsMaximumLength {
+  // Test that a 32-character valid identifier is accepted and not truncated.
+  NSString *maxLength = @"abcdefghijklmnopqrstuvwxyz123456"; // 32 chars
+  [GIDSignInPreferences setWrapperIdentifier:maxLength];
+  XCTAssertEqual([GIDSignInPreferences wrapperIdentifier].length, (NSUInteger)32);
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], maxLength);
 }
 
-- (void)testWrapperIdentifier_TrimsWhitespace {
-  // Test that leading and trailing whitespace is trimmed from the identifier.
-  GIDSetWrapperIdentifier(@"  firebase  ");
-  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"firebase");
+- (void)testWrapperIdentifier_RejectsUppercase {
+  // Test that uppercase characters cause a rejection.
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"Firebase"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
 }
 
-- (void)testWrapperIdentifier_EmptyOrWhitespaceBecomesNil {
-  // Test that empty or whitespace-only strings result in a nil identifier.
-  GIDSetWrapperIdentifier(@"   ");
-  XCTAssertNil(GIDWrapperIdentifier());
+- (void)testWrapperIdentifier_RejectsWhitespace {
+  // Test that leading/trailing or internal whitespace cause a rejection.
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"  firebase  "],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
 
-  // Test that a string consisting only of invalid characters results in a nil identifier.
-  GIDSetWrapperIdentifier(@"!!!");
-  XCTAssertNil(GIDWrapperIdentifier());
+  [GIDSignInPreferences setWrapperIdentifier:nil];
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"fire base"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
 }
 
-- (void)testWrapperIdentifier_CapsAtThirtyTwoCharacters {
-  // Test that the identifier is truncated to a maximum of 32 characters.
-  NSString *longString = @"abcdefghijklmnopqrstuvwxyz1234567890"; // 36 characters
-  GIDSetWrapperIdentifier(longString);
-  NSString *result = GIDWrapperIdentifier();
-  XCTAssertEqual(result.length, (NSUInteger)32);
-  XCTAssertEqualObjects(result, [longString.lowercaseString substringToIndex:32]);
+- (void)testWrapperIdentifier_RejectsPunctuation {
+  // Test that disallowed punctuation causes a rejection.
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"my-sdk_1.2~x"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+
+  [GIDSignInPreferences setWrapperIdentifier:nil];
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"fire!base"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
 }
 
-- (void)testWrapperIdentifier_LastWriteWins {
-  // Test that subsequent writes overwrite the previous identifier.
-  GIDSetWrapperIdentifier(@"first");
-  GIDSetWrapperIdentifier(@"second");
-  XCTAssertEqualObjects(GIDWrapperIdentifier(), @"second");
+- (void)testWrapperIdentifier_RejectsEmpty {
+  // Test that an empty string is rejected.
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@""],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+}
 
-  // Test that setting it to nil clears the identifier.
-  GIDSetWrapperIdentifier(nil);
-  XCTAssertNil(GIDWrapperIdentifier());
+- (void)testWrapperIdentifier_RejectsOverLength {
+  // Test that a 33-character identifier is rejected.
+  NSString *overLength = @"abcdefghijklmnopqrstuvwxyz1234567"; // 33 chars
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:overLength],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+}
+
+- (void)testWrapperIdentifier_RejectsLeadingOrTrailingHyphen {
+  // Test that leading or trailing hyphens cause a rejection.
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"-sdk"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+
+  [GIDSignInPreferences setWrapperIdentifier:nil];
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"sdk-"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+}
+
+- (void)testWrapperIdentifier_FirstValidWriteWins {
+  // Test that the first valid write is persistent and subsequent differing writes are rejected.
+  [GIDSignInPreferences setWrapperIdentifier:@"first"];
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"second"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"first");
+}
+
+- (void)testWrapperIdentifier_RepeatedIdenticalWriteIsAccepted {
+  // Test that writing the same valid value again does not throw or change the state.
+  [GIDSignInPreferences setWrapperIdentifier:@"firebase"];
+  XCTAssertNoThrow([GIDSignInPreferences setWrapperIdentifier:@"firebase"]);
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"firebase");
+}
+
+- (void)testWrapperIdentifier_NilResets {
+  // Test that passing nil resets the store, allowing a new first-write.
+  [GIDSignInPreferences setWrapperIdentifier:@"firebase"];
+  [GIDSignInPreferences setWrapperIdentifier:nil];
+  XCTAssertNil([GIDSignInPreferences wrapperIdentifier]);
+
+  [GIDSignInPreferences setWrapperIdentifier:@"second"];
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"second");
+}
+
+- (void)testWrapperIdentifier_RejectedWriteLeavesPreviousValue {
+  // Test that a rejected write does not clear or change a previously set valid value.
+  [GIDSignInPreferences setWrapperIdentifier:@"firebase"];
+  XCTAssertThrowsSpecificNamed([GIDSignInPreferences setWrapperIdentifier:@"Invalid!"],
+                               NSException,
+                               NSInternalInconsistencyException);
+  XCTAssertEqualObjects([GIDSignInPreferences wrapperIdentifier], @"firebase");
 }
 
 @end

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -1217,13 +1217,15 @@ static NSString *const kMultipleClaimsJsonString =
                "when unset.");
 }
 
-- (void)testWrapperIdentifier_PropertyReflectsSanitizedValue {
-  GIDSignIn.sharedInstance.wrapperIdentifier = @"Fire Base!";
-  XCTAssertEqualObjects(GIDSignIn.sharedInstance.wrapperIdentifier, @"firebase",
-                        @"The wrapperIdentifier property should reflect the sanitized value.");
+- (void)testWrapperIdentifier_InvalidValueIsIgnored {
+  XCTAssertThrowsSpecificNamed(GIDSignIn.sharedInstance.wrapperIdentifier = @"Fire Base!",
+                               NSException, NSInternalInconsistencyException,
+                               @"Setting an invalid wrapper identifier should throw.");
+  XCTAssertNil(GIDSignIn.sharedInstance.wrapperIdentifier,
+               @"The wrapper identifier should be nil after an invalid assignment.");
 }
 
-- (void)testWrapperIdentifier_PercentEncodedOnRevokeURL {
+- (void)testWrapperIdentifier_PresentOnRevokeURL {
   GIDSignIn.sharedInstance.wrapperIdentifier = @"my-sdk";
 
   [[[_authorization expect] andReturn:_authState] authState];
@@ -1235,9 +1237,51 @@ static NSString *const kMultipleClaimsJsonString =
 
   XCTAssertTrue([self isFetcherStarted], @"should start fetching");
   NSURL *url = [self fetchedURL];
-  NSString *urlString = url.absoluteString;
-  XCTAssertTrue([urlString containsString:@"gidwrapper=my-sdk"],
-                @"The revoke URL should contain the percent-encoded 'gidwrapper' parameter.");
+  NSURLComponents *components = [NSURLComponents componentsWithURL:url
+                                           resolvingAgainstBaseURL:NO];
+  NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
+
+  XCTAssertEqualObjects([self valueForQueryItemName:@"gidwrapper" inArray:queryItems],
+                        @"my-sdk", @"The revoke URL should contain the 'gidwrapper' parameter.");
+  XCTAssertEqualObjects([self valueForQueryItemName:kSDKVersionLoggingParameter inArray:queryItems],
+                        [GIDSignInPreferences sdkVersion],
+                        @"The revoke URL should contain the SDK version parameter.");
+  XCTAssertEqualObjects([self valueForQueryItemName:kEnvironmentLoggingParameter
+                                            inArray:queryItems],
+                        [GIDSignInPreferences environment],
+                        @"The revoke URL should contain the environment parameter.");
+  XCTAssertEqualObjects([self valueForQueryItemName:@"token" inArray:queryItems],
+                        kAccessToken, @"The revoke URL should contain the 'token' parameter.");
+}
+
+- (void)testWrapperIdentifier_AbsentFromRevokeURLWhenUnset {
+  GIDSignIn.sharedInstance.wrapperIdentifier = nil;
+
+  [[[_authorization expect] andReturn:_authState] authState];
+  [[[_authState expect] andReturn:_tokenResponse] lastTokenResponse];
+  [[[_tokenResponse expect] andReturn:kAccessToken] accessToken];
+  [[[_authorization expect] andReturn:_fetcherService] fetcherService];
+
+  [_signIn disconnectWithCompletion:nil];
+
+  XCTAssertTrue([self isFetcherStarted], @"should start fetching");
+  NSURL *url = [self fetchedURL];
+  NSURLComponents *components = [NSURLComponents componentsWithURL:url
+                                           resolvingAgainstBaseURL:NO];
+  NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
+
+  XCTAssertNil([self valueForQueryItemName:@"gidwrapper" inArray:queryItems],
+               @"The revoke URL should not contain the 'gidwrapper' parameter when unset.");
+  XCTAssertEqualObjects([self valueForQueryItemName:kSDKVersionLoggingParameter inArray:queryItems],
+                        [GIDSignInPreferences sdkVersion],
+                        @"The revoke URL should still contain the SDK version parameter.");
+  XCTAssertEqualObjects([self valueForQueryItemName:kEnvironmentLoggingParameter
+                                            inArray:queryItems],
+                        [GIDSignInPreferences environment],
+                        @"The revoke URL should still contain the environment parameter.");
+  XCTAssertEqualObjects([self valueForQueryItemName:@"token" inArray:queryItems],
+                        kAccessToken,
+                        @"The revoke URL should still contain the 'token' parameter.");
 }
 
 - (void)testOAuthLogin_ConsentCanceled {
@@ -1753,6 +1797,17 @@ static NSString *const kMultipleClaimsJsonString =
 
 #pragma mark - Helpers
 
+// Returns the value for the query item with the given name in the array of query items.
+- (nullable NSString *)valueForQueryItemName:(NSString *)name
+                                     inArray:(NSArray<NSURLQueryItem *> *)queryItems {
+  for (NSURLQueryItem *item in queryItems) {
+    if ([item.name isEqualToString:name]) {
+      return item.value;
+    }
+  }
+  return nil;
+}
+
 // Whether or not a fetcher has been started.
 - (BOOL)isFetcherStarted {
   NSUInteger count = _fetcherService.fetchers.count;
@@ -1795,9 +1850,11 @@ static NSString *const kMultipleClaimsJsonString =
   NSDictionary<NSString *, NSObject<NSCopying> *> *params = queryComponent.dictionaryValue;
   XCTAssertEqualObjects([params valueForKey:@"token"], token,
                         @"token parameter should match");
-  XCTAssertEqualObjects([params valueForKey:kSDKVersionLoggingParameter], GIDVersion(),
+  XCTAssertEqualObjects([params valueForKey:kSDKVersionLoggingParameter],
+                        [GIDSignInPreferences sdkVersion],
                         @"SDK version logging parameter should match");
-  XCTAssertEqualObjects([params valueForKey:kEnvironmentLoggingParameter], GIDEnvironment(),
+  XCTAssertEqualObjects([params valueForKey:kEnvironmentLoggingParameter],
+                        [GIDSignInPreferences environment],
                         @"Environment logging parameter should match");
   // Emulate result back from server.
   [self didFetch:nil error:nil];
@@ -1963,8 +2020,8 @@ static NSString *const kMultipleClaimsJsonString =
     XCTAssertNotNil(_savedAuthorizationRequest);
     NSDictionary<NSString *, NSObject *> *params = _savedAuthorizationRequest.additionalParameters;
     XCTAssertEqualObjects(params[@"include_granted_scopes"], @"true");
-    XCTAssertEqualObjects(params[kSDKVersionLoggingParameter], GIDVersion());
-    XCTAssertEqualObjects(params[kEnvironmentLoggingParameter], GIDEnvironment());
+    XCTAssertEqualObjects(params[kSDKVersionLoggingParameter], [GIDSignInPreferences sdkVersion]);
+    XCTAssertEqualObjects(params[kEnvironmentLoggingParameter], [GIDSignInPreferences environment]);
     XCTAssertNotNil(_savedAuthorizationCallback);
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
     XCTAssertEqual(_savedPresentingViewController, _presentingViewController);

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -389,6 +389,7 @@ static NSString *const kMultipleClaimsJsonString =
   [_testUserDefaults removePersistentDomainForName:kUserDefaultsSuiteName];
 
   [_fakeMainBundle stopFaking];
+  GIDSignIn.sharedInstance.wrapperIdentifier = nil;
   [super tearDown];
 }
 
@@ -1166,6 +1167,77 @@ static NSString *const kMultipleClaimsJsonString =
 
   NSDictionary<NSString *, NSObject *> *params = _savedAuthorizationRequest.additionalParameters;
   XCTAssertEqualObjects(params[@"hd"], kHostedDomain, @"hosted domain should match");
+}
+
+- (void)testWrapperIdentifier_PresentInAuthorizationRequestWhenSet {
+  GIDSignIn.sharedInstance.wrapperIdentifier = @"firebase";
+  OCMStub(
+    [_keychainStore saveAuthSession:OCMOCK_ANY error:OCMArg.anyObjectRef]
+  ).andDo(^(NSInvocation *invocation) {
+    self->_keychainSaved = self->_saveAuthorizationReturnValue;
+  });
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+               claimsAsJSONRequired:NO
+                      keychainError:NO
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO];
+
+  NSDictionary<NSString *, NSObject *> *params = _savedAuthorizationRequest.additionalParameters;
+  XCTAssertEqualObjects(params[@"gidwrapper"], @"firebase",
+                        @"The authorization request should contain the 'gidwrapper' parameter "
+                        "when set.");
+}
+
+- (void)testWrapperIdentifier_AbsentFromAuthorizationRequestWhenUnset {
+  GIDSignIn.sharedInstance.wrapperIdentifier = nil;
+  OCMStub(
+    [_keychainStore saveAuthSession:OCMOCK_ANY error:OCMArg.anyObjectRef]
+  ).andDo(^(NSInvocation *invocation) {
+    self->_keychainSaved = self->_saveAuthorizationReturnValue;
+  });
+
+  [self OAuthLoginWithAddScopesFlow:NO
+                          authError:nil
+                         tokenError:nil
+            emmPasscodeInfoRequired:NO
+               claimsAsJSONRequired:NO
+                      keychainError:NO
+                     restoredSignIn:NO
+                     oldAccessToken:NO
+                        modalCancel:NO];
+
+  NSDictionary<NSString *, NSObject *> *params = _savedAuthorizationRequest.additionalParameters;
+  XCTAssertNil(params[@"gidwrapper"],
+               @"The authorization request should not contain the 'gidwrapper' parameter "
+               "when unset.");
+}
+
+- (void)testWrapperIdentifier_PropertyReflectsSanitizedValue {
+  GIDSignIn.sharedInstance.wrapperIdentifier = @"Fire Base!";
+  XCTAssertEqualObjects(GIDSignIn.sharedInstance.wrapperIdentifier, @"firebase",
+                        @"The wrapperIdentifier property should reflect the sanitized value.");
+}
+
+- (void)testWrapperIdentifier_PercentEncodedOnRevokeURL {
+  GIDSignIn.sharedInstance.wrapperIdentifier = @"my-sdk";
+
+  [[[_authorization expect] andReturn:_authState] authState];
+  [[[_authState expect] andReturn:_tokenResponse] lastTokenResponse];
+  [[[_tokenResponse expect] andReturn:kAccessToken] accessToken];
+  [[[_authorization expect] andReturn:_fetcherService] fetcherService];
+
+  [_signIn disconnectWithCompletion:nil];
+
+  XCTAssertTrue([self isFetcherStarted], @"should start fetching");
+  NSURL *url = [self fetchedURL];
+  NSString *urlString = url.absoluteString;
+  XCTAssertTrue([urlString containsString:@"gidwrapper=my-sdk"],
+                @"The revoke URL should contain the percent-encoded 'gidwrapper' parameter.");
 }
 
 - (void)testOAuthLogin_ConsentCanceled {

--- a/GoogleSignIn/Tests/Unit/GIDSignInTest.m
+++ b/GoogleSignIn/Tests/Unit/GIDSignInTest.m
@@ -1217,12 +1217,12 @@ static NSString *const kMultipleClaimsJsonString =
                "when unset.");
 }
 
-- (void)testWrapperIdentifier_InvalidValueIsIgnored {
-  XCTAssertThrowsSpecificNamed(GIDSignIn.sharedInstance.wrapperIdentifier = @"Fire Base!",
+- (void)testWrapperIdentifier_DroppedValueIsIgnored {
+  XCTAssertThrowsSpecificNamed(GIDSignIn.sharedInstance.wrapperIdentifier = @"firebasé",
                                NSException, NSInternalInconsistencyException,
-                               @"Setting an invalid wrapper identifier should throw.");
+                               @"Setting a dropped wrapper identifier should throw.");
   XCTAssertNil(GIDSignIn.sharedInstance.wrapperIdentifier,
-               @"The wrapper identifier should be nil after an invalid assignment.");
+               @"The wrapper identifier should be nil after a dropped assignment.");
 }
 
 - (void)testWrapperIdentifier_PresentOnRevokeURL {


### PR DESCRIPTION
A small number of clients bundle GoogleSignIn-iOS with their own SDKs. To ensure that the way we understand adoption of the SDK is accurate, we'd like to allow those bundlers to say "Hi, this clientID may be App123, but I, Bundler0, am handling it on their behalf".

This is entirely optional and represents no functional change to the way authorization requests are handled on the backend.